### PR TITLE
Included arming in inherited "on" method

### DIFF
--- a/Modules/+Sources/Laser532_PB.m
+++ b/Modules/+Sources/Laser532_PB.m
@@ -71,6 +71,7 @@ classdef Laser532_PB < Modules.Source & Sources.Verdi_invisible
             end
         end
         function on(obj)
+            on@Sources.Verdi_invisible(obj);
             assert(~isempty(obj.PulseBlaster),'No IP set!')
             obj.PulseBlaster.lines(obj.PBline) = true;
             obj.source_on = true;

--- a/Modules/+Sources/Laser532_nidaq.m
+++ b/Modules/+Sources/Laser532_nidaq.m
@@ -49,6 +49,7 @@ classdef Laser532_nidaq < Modules.Source & Sources.Verdi_invisible
             delete(obj.listeners)
         end
         function on(obj)
+            on@Sources.Verdi_invisible(obj);
             obj.ni.WriteDOLines('532 Laser',1)
         end
         function off(obj)

--- a/Modules/+Sources/Verdi_invisible.m
+++ b/Modules/+Sources/Verdi_invisible.m
@@ -19,6 +19,11 @@ classdef Verdi_invisible < handle
                 obj.enabled = true;
             end
         end
+        function on(obj)
+            if ~obj.enabled % Will only slow down if forgot to arm
+                obj.arm()
+            end
+        end
         function delete(obj)
             obj.inactive;
         end


### PR DESCRIPTION
small enhancement to make sure experiments don't proceed inadvertently with the main laser off. Note, the laser has a period where it is turning on and stabilizing that is not accounted for here. It is perhaps a good idea to have a ready state on the laser that the setups can reference, but that is a further enhancement. Currently you might get a few minutes of bad data while it warms up; but you won't lose an entire night.