### PR TITLE
Removal of client-side abort call

### DIFF
--- a/HelperFunctions/hwserver.m
+++ b/HelperFunctions/hwserver.m
@@ -74,7 +74,10 @@ classdef hwserver < handle
                 fprintf(obj.connection,'%s\n',msg);
                 response = obj.receive;
             catch err
-                fprintf(obj.connection,'%s\n',abort);
+                % For future use in more parallel hwserver;
+                % for now, it is redundant with keep_alive: false and is
+                % error-prone server-side if called too quickly
+                % fprintf(obj.connection,'%s\n',abort);
             end
             fclose(obj.connection);
             if ~isempty(err)


### PR DESCRIPTION
This abort call, upon error on client-side, is sent to the server.  The current configuration of hwserver doesn't listen for client messages async.  As such, this call is not helpful, and has resulted in scenarios where the client sends back-to-back requests which the server resolves as an error since two concatenated json objects do not decode as a json object.  I can't reproduce this error, and don't understand why it happens yet (EMM/solstis are the culprit).