### PR TITLE
Updated obj.meta

### DIFF
--- a/Modules/+Experiments/+AutoExperiment/@AutoExperiment_invisible/run.m
+++ b/Modules/+Experiments/+AutoExperiment/@AutoExperiment_invisible/run.m
@@ -163,7 +163,7 @@ try
     end
 catch err
 end
-obj.meta.tstop = toc(runstart);
+obj.meta.tstop = datetime('now');
 obj.meta.tracker = obj.tracker;
 obj.PostRun(status,managers,ax)
 obj.continue_experiment = false;


### PR DESCRIPTION
Now includes:
```
obj.meta.tracker = obj.tracker  # Should have included this from the start!
obj.meta.tstart = datetime    # store full datetime to position experiment in absolute time
obj.meta.tstop = toc(runstart)   # relative time

obj.sites(site_i).experiments(exp_i).tstart = toc(runstart) # relative start time
obj.sites(site_i).experiments(exp_i).tstop = toc(runstart) # relative end time