### PR TITLE
QR Reader

### DIFF
--- a/+Base/@QR/QR.m
+++ b/+Base/@QR/QR.m
@@ -194,11 +194,9 @@ classdef QR
             if ~strcmp(code(pad),padVal)
                 % There was a flaw in some of the generation code, so
                 % attempt altering code to "fix" by swapping bit 5 and 6
-                if ~strcmp(code([1 6]),padVal)
-                    error('Padding bits are incorrect.')
-                else
-                    legacy_error = true;
-                    code([1 6]) = [];
+                assert(strcmp(code([1 6]),padVal),'Padding bits are incorrect.')
+                legacy_error = true;
+                code([1 6]) = [];
                 end
             else
                 code(pad) = [];


### PR DESCRIPTION
Added legacy support for QR errors prior to version 5.  There was an issue with how the padding bits were added in QR generation making them actually be at locations [1 6] (indexed by 1) instead of [1 5].  Since then, QR generation has been fixed and the version number incremented.  The reader has been adapted to test this case.