### PR TITLE
Peakfun

### DIFF
--- a/HelperFunctions/PeakFitting/+NV/ODMR.m
+++ b/HelperFunctions/PeakFitting/+NV/ODMR.m
@@ -122,7 +122,7 @@ else % gauss
 end
 
 outstruct = struct('C13',[],'iso',[],'fit',[],...
-        'sse',[],'rsquare',[],'dfe',[],'adjrsquare',[],'rmse',{});
+        'sse',[],'rsquare',[],'dfe',[],'adjrsquare',[],'rmse',{},'output',[]);
 pp = gcp('nocreate'); % If no pool, do not create new one.
 if isempty(pp)
     nworkers = 0;


### PR DESCRIPTION
Added a file NV.ODMR to fit single-sided ODMR peaks (e.g. a magnet is necessary to split out transitions far enough that +1/-1 don't appear together).  Uses a parallel pool if already started.