### PR TITLE
Avoid user prompts during middle of exp

### DIFF
--- a/Modules/+Sources/@VelocityLaser/VelocityLaser.m
+++ b/Modules/+Sources/@VelocityLaser/VelocityLaser.m
@@ -257,6 +257,8 @@ classdef VelocityLaser < Modules.Source & Sources.TunableLaser_invisible
             obj.PulseBlaster.lines(obj.PBline) = false;
         end
         function arm(obj)
+            % Make sure calibration is available
+            cal = obj.calibration;
             if ~obj.diode_on
                 obj.activate;
             end


### PR DESCRIPTION
- Adds calibration check in arm method
- Calls arm method in PreRun to avoid situation of user prompt half way through running experiment.
- Enforce same laser used for both SlowScans - mainly because nm2THz is only saved for Slow.Open.  Pretty easy to change, I think, However, that can be for a future enhancement after more careful thought of other potential ramifications.