### PR TITLE
Pulse timer invisible

### DIFF
--- a/HelperFunctions/PulseSequence/APDPulseSequence.m
+++ b/HelperFunctions/PulseSequence/APDPulseSequence.m
@@ -16,8 +16,6 @@ classdef APDPulseSequence < handle
             obj.ni = ni;
             obj.seq = seq;
             obj.pb = pb;
-            obj.seq.resolution = obj.pb.resolution;  
-            obj.seq.minDuration = obj.pb.minDuration; 
             % Verify chanels exist in nidaq
             chans = seq.getSequenceChannels;
             chans(cellfun(@(a)isempty(a),{chans.counter}))=[];

--- a/HelperFunctions/PulseSequence/APDPulseSequence.m
+++ b/HelperFunctions/PulseSequence/APDPulseSequence.m
@@ -16,6 +16,8 @@ classdef APDPulseSequence < handle
             obj.ni = ni;
             obj.seq = seq;
             obj.pb = pb;
+            obj.seq.resolution = obj.pb.resolution;  
+            obj.seq.minDuration = obj.pb.minDuration; 
             % Verify chanels exist in nidaq
             chans = seq.getSequenceChannels;
             chans(cellfun(@(a)isempty(a),{chans.counter}))=[];

--- a/Modules/+Drivers/+PulseBlaster/Remote.m
+++ b/Modules/+Drivers/+PulseBlaster/Remote.m
@@ -5,9 +5,7 @@ classdef Remote < Modules.Driver & Drivers.PulseTimer_invisible
     % Call with the IP of the host computer (singleton based on ip)
     
     properties
-        clk = 500  % Hz (isn't this MHz?)
-        resolution = 2; % ns
-        minDuration = 10; % ns
+        clk = 500  % Hz
     end
     properties(SetAccess=private)
         connection

--- a/Modules/+Drivers/+PulseBlaster/Remote.m
+++ b/Modules/+Drivers/+PulseBlaster/Remote.m
@@ -6,6 +6,9 @@ classdef Remote < Modules.Driver & Drivers.PulseTimer_invisible
     
     properties
         clk = 500  % Hz
+        resolution = 2;  % ns
+        minDuration = 10;% Minimum duration in ns
+        maxRepeats = 2^20;  % positive integer value
     end
     properties(SetAccess=private)
         connection

--- a/Modules/+Drivers/+PulseBlaster/Remote.m
+++ b/Modules/+Drivers/+PulseBlaster/Remote.m
@@ -1,11 +1,13 @@
-classdef Remote < Modules.Driver
+classdef Remote < Modules.Driver & Drivers.PulseTimer_invisible
     %INTERPRETERCLIENT Connects with server.py on host machine to control
     % the PulseBlaster via the interpreter program. Port 36576.
     %
     % Call with the IP of the host computer (singleton based on ip)
     
     properties
-        clk = 500  % Hz
+        clk = 500  % Hz (isn't this MHz?)
+        resolution = 2; % ns
+        minDuration = 10; % ns
     end
     properties(SetAccess=private)
         connection

--- a/Modules/+Drivers/PulseTimer_invisible.m
+++ b/Modules/+Drivers/PulseTimer_invisible.m
@@ -1,0 +1,50 @@
+classdef PulseTimer_invisible < handle
+    %PulseTimer_invisible Superclass for all pulse sequence hardware
+    %Properties:
+    %   clk: internal or external clock rate of pusle sequence hardware.
+    %   resolution: timining resolution of pulse sequence hardware.
+    %   minDuration: minimum pusle duration of pulse sequence hardware. 
+    %Methods:
+    %   reset: reset device to default settings
+    %   start: run pulse sequence 
+    %   load: load pulse sequence program into memory of puslse timing
+    %   hardware
+    %   stop: stop pulse sequence and output default value (low).
+        
+    properties(Abstract)
+        clk;         % MHz
+        resolution;  % ns
+        minDuration;% Minimum duration in ns
+    end
+    
+    methods(Abstract)
+        
+        function obj = PulseTimer_invisible()
+        end  
+        
+        function reset(~,varargin)
+            % reset timing device (may have different definitions depending
+            % on device)
+            error('Method Reset not defined')
+        end
+        
+        function start(~,varargin)
+            % start pulse sequence
+            error('Method Start not defined')
+        end
+        
+        function load(~,varargin)
+            % load pusle sequence to hardware
+            error('Method Load not defined')
+        end
+         
+        function stop(~,varargin)
+            % stop the pulse sequence 
+            error('Method Stop not defined')
+        end
+        
+    end
+    
+end
+
+    

--- a/Modules/+Drivers/PulseTimer_invisible.m
+++ b/Modules/+Drivers/PulseTimer_invisible.m
@@ -13,8 +13,9 @@ classdef PulseTimer_invisible < handle
         
     properties(Abstract)
         clk;         % MHz
-        resolution;  % ns
-        minDuration;% Minimum duration in ns
+        % resolution;  % ns
+        % minDuration; % Minimum duration in ns
+        % maxRepitiions; % Maximum number of repitions
     end
     
     methods(Abstract)

--- a/Modules/+Drivers/PulseTimer_invisible.m
+++ b/Modules/+Drivers/PulseTimer_invisible.m
@@ -12,10 +12,7 @@ classdef PulseTimer_invisible < handle
     %   stop: stop pulse sequence and output default value (low).
         
     properties(Abstract)
-        clk;         % MHz
-        % resolution;  % ns
-        % minDuration; % Minimum duration in ns
-        % maxRepitiions; % Maximum number of repitions
+        clk;         % clock sampling rate
     end
     
     methods(Abstract)

--- a/Modules/+Drivers/PulseTimer_invisible.m
+++ b/Modules/+Drivers/PulseTimer_invisible.m
@@ -1,7 +1,10 @@
 classdef PulseTimer_invisible < handle
     %PulseTimer_invisible Superclass for all pulse sequence hardware
     %Properties:
-    %   clk: internal or external clock rate of pusle sequence hardware.
+    %   clk: internal or external clock rate of pulse sequence hardware.
+    %   resolution: timinig resolution of pulse sequence hardware
+    %   minDuration: minimum pulse duration of pulse sequence hardware.
+    %   maxRepeats; maximum number of pulse sequence repetitions.
     %Methods:
     %   reset: reset device to default settings
     %   start: run pulse sequence 
@@ -11,34 +14,24 @@ classdef PulseTimer_invisible < handle
         
     properties(Abstract)
         clk;         % clock sampling rate
+        resolution;  % ns
+        minDuration; % ns
+        maxRepeats;  % positive integer value
     end
     
+    methods
+        function obj = PulseTimer_invisible() 
+        end
+    end
     methods(Abstract)
-        
-        function obj = PulseTimer_invisible()
-        end  
-        
-        function reset(~,varargin)
-            % reset timing device (may have different definitions depending
+        reset(~,varargin) % reset timing device (may have different definitions depending
             % on device)
-            error('Method Reset not defined')
-        end
-        
-        function start(~,varargin)
-            % start pulse sequence
-            error('Method Start not defined')
-        end
-        
-        function load(~,varargin)
-            % load pusle sequence to hardware
-            error('Method Load not defined')
-        end
-         
-        function stop(~,varargin)
-            % stop the pulse sequence 
-            error('Method Stop not defined')
-        end
-        
+
+        start(~,varargin)  % start pulse sequence
+
+        load(~,varargin) % load pusle sequence to hardware
+
+        stop(~,varargin) % stop the pulse sequence     
     end
     
 end

--- a/Modules/+Drivers/PulseTimer_invisible.m
+++ b/Modules/+Drivers/PulseTimer_invisible.m
@@ -12,7 +12,7 @@ classdef PulseTimer_invisible < handle
     %   hardware
     %   stop: stop pulse sequence and output default value (e.g. all channels low).
         
-    properties(Abstract)
+    properties(Constant,Abstract)
         clk;         % clock sampling rate
         resolution;  % ns
         minDuration; % ns
@@ -24,14 +24,14 @@ classdef PulseTimer_invisible < handle
         end
     end
     methods(Abstract)
-        reset(~,varargin) % reset timing device (may have different definitions depending
+        reset(obj) % reset timing device (may have different definitions depending
             % on device)
 
-        start(~,varargin)  % start pulse sequence
+        start(obj)  % start pulse sequence
 
-        load(~,varargin) % load pusle sequence to hardware
+        load(obj,program) % load pusle sequence program to hardware
 
-        stop(~,varargin) % stop the pulse sequence     
+        stop(obj) % stop the pulse sequence     
     end
     
 end

--- a/Modules/+Drivers/PulseTimer_invisible.m
+++ b/Modules/+Drivers/PulseTimer_invisible.m
@@ -2,14 +2,12 @@ classdef PulseTimer_invisible < handle
     %PulseTimer_invisible Superclass for all pulse sequence hardware
     %Properties:
     %   clk: internal or external clock rate of pusle sequence hardware.
-    %   resolution: timining resolution of pulse sequence hardware.
-    %   minDuration: minimum pusle duration of pulse sequence hardware. 
     %Methods:
     %   reset: reset device to default settings
     %   start: run pulse sequence 
     %   load: load pulse sequence program into memory of puslse timing
     %   hardware
-    %   stop: stop pulse sequence and output default value (low).
+    %   stop: stop pulse sequence and output default value (e.g. all channels low).
         
     properties(Abstract)
         clk;         % clock sampling rate


### PR DESCRIPTION
Created superclass PulseTimer_invisible which all timing devices (e.g. pulseBlaster) must inherit from to guarantee each timing device has methods load, start, stop, reset and property clk. 