### PR TITLE
New analysis format, moved lots of code

### DIFF
--- a/Modules/+Drivers/WinSpec.m
+++ b/Modules/+Drivers/WinSpec.m
@@ -361,6 +361,15 @@ classdef WinSpec < Modules.Driver
                 rethrow(err)
             end
         end
+        function set_calibration(obj,cfit_obj,gof)
+            assert(isa(cfit_obj,'cfit'),...
+                    sprintf('analysis.nm2THz should be a cfit, not "%s"',class(obj.analysis.nm2THz)));
+            obj.cal_local.nm2THz = cfit_obj;
+            obj.cal_local.gof = gof;
+            obj.cal_local.datetime = datetime;
+            obj.cal_local.source = 'Manually set';
+            
+        end
         
         function cal = calibration(obj,varargin)
             %get the calibration of the spectrometer; this is stored as 

--- a/Modules/+Drivers/WinSpec.m
+++ b/Modules/+Drivers/WinSpec.m
@@ -363,7 +363,7 @@ classdef WinSpec < Modules.Driver
         end
         function set_calibration(obj,cfit_obj,gof)
             assert(isa(cfit_obj,'cfit'),...
-                    sprintf('analysis.nm2THz should be a cfit, not "%s"',class(obj.analysis.nm2THz)));
+                    sprintf('analysis.nm2THz should be a cfit, not "%s"',class(cfit_obj)));
             obj.cal_local.nm2THz = cfit_obj;
             obj.cal_local.gof = gof;
             obj.cal_local.datetime = datetime;

--- a/Modules/+Experiments/+AutoExperiment/@AutoExperiment_invisible/run.m
+++ b/Modules/+Experiments/+AutoExperiment/@AutoExperiment_invisible/run.m
@@ -87,7 +87,7 @@ try
                 % Check redo flag for this site and this experiment
                 redo = false;
                 if ~isempty(obj.analysis)
-                    redo = obj.analysis(site_index,exp_index).redo;
+                    redo = obj.analysis.sites(site_index,exp_index).redo;
                     for j = find(prev_mask) % Update previous run's redo flag
                         obj.data.sites(site_index).experiments(j).redo_requested = redo;
                     end

--- a/Modules/+Experiments/+AutoExperiment/@AutoExperiment_invisible/run.m
+++ b/Modules/+Experiments/+AutoExperiment/@AutoExperiment_invisible/run.m
@@ -1,8 +1,9 @@
 function run(obj,status,managers,ax)
 obj.abort_request = false;
 obj.fatal_flag = false;
+nexps = length(obj.experiments);
 assert(all(cellfun(@ischar,obj.patch_functions)),'One or more patch function is not a valid handle.');
-assert(length(obj.patch_functions) == length(obj.experiments),'Number of patch functions does not match number of experiments.')
+assert(length(obj.patch_functions) == nexps,'Number of patch functions does not match number of experiments.')
 assert(~isempty(obj.imaging_source),'No imaging source selected, please select one and re-run.')
 
 if isempty(managers.Imaging.modules) || isempty(managers.Stages.modules)
@@ -56,9 +57,9 @@ end
 nsites = length(obj.data.sites);
 switch obj.run_type
     case obj.SITES_FIRST
-        [Y,X] = meshgrid(1:length(obj.experiments),1:nsites);
+        [Y,X] = meshgrid(1:nexps,1:nsites);
     case obj.EXPERIMENTS_FIRST
-        [X,Y] = meshgrid(1:nsites,1:length(obj.experiments));
+        [X,Y] = meshgrid(1:nsites,1:nexps);
     otherwise
         error('Unknown run_type %s',obj.run_type)
 end
@@ -74,12 +75,12 @@ err = [];
 try
     for repetition = 1:obj.repeat
         for i=1:size(run_queue,1)
-            status.String = 'Searching for next experiment to run...';
             try
-                drawnow limitrate;
-                assert(~obj.abort_request,'User aborted'); % Allows aborting before running any experiments
                 site_index = run_queue(i,1);
                 exp_index = run_queue(i,2);
+                status.String = sprintf('Searching for next experiment to run\nSite: %i/%i\nExperiment: %i/%i)...',site_index,nsites,exp_index,nexps);
+                drawnow limitrate;
+                assert(~obj.abort_request,'User aborted'); % Allows aborting before running any experiments
                 experiment = obj.experiments(exp_index); %grab experiment instance
                 mask = ismember({obj.data.sites(site_index).experiments.name},class(experiment));
                 last_attempt = min([[obj.data.sites(site_index).experiments(mask).continued] Inf]); % Abort could leave a gap (Inf for first time through)

--- a/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/SpecSlowScan.m
+++ b/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/SpecSlowScan.m
@@ -186,9 +186,12 @@ classdef SpecSlowScan < Experiments.AutoExperiment.AutoExperiment_invisible
         function PreRun(obj,status,managers,ax)
             %before running, calibrate spectrometer and check resLaser
             status.String = 'Checking spectrometer and resLaser'; drawnow;
+            assert(~isempty(obj.experiments(2).repumpLaser),'SlowScan.Open needs a repump laser defined!');
+            assert(~isempty(obj.experiments(3).repumpLaser),'SlowScan.Closed needs a repump laser defined!');
+            assert(~isempty(obj.experiments(2).resLaser),'SlowScan.Open needs a resonant laser defined!');
+            assert(~isempty(obj.experiments(3).resLaser),'SlowScan.Closed needs a resonant laser defined!');
             specH = obj.experiments(1).WinSpec;
             laserH = obj.experiments(2).resLaser;
-            assert(~isempty(laserH),'No laser selected for SlowScan experiment(s)!');
             assert(isequal(laserH,obj.experiments(3).resLaser),...
                 'Currently, SpecSlowScan only supports using the same resLaser for SlowScan.Open and SlowScan.Closed.');
             laserH.arm; % Go through arming now to make sure things are set at the beginning (e.g. calibration if it exists)

--- a/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/SpecSlowScan.m
+++ b/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/SpecSlowScan.m
@@ -175,7 +175,7 @@ classdef SpecSlowScan < Experiments.AutoExperiment.AutoExperiment_invisible
             sites = Experiments.AutoExperiment.AutoExperiment_invisible.SiteFinder_Confocal(managers,obj.imaging_source,obj.site_selection);
         end
         function validate_analysis(obj)
-            for i = 1:n_data_sites
+            for i = 1:size(obj.analysis.sites,1)
                 for j = 1:3 % The 3 is for n experiments, which was validated in superclass
                     assert(isnan(obj.analysis.sites(i,j).index) || (obj.analysis.sites(i,j).index == i),...
                         ['At least one analysis index does not reference its position (also corresponding to data position). ',...


### PR DESCRIPTION
made some massive changes to data pipeline especially with analysis stuff. The idea is to do three things:
1. not require re-loading the data file (e.g. redo flag is now incorporated into analysis struct, not modifying data struct)
2. direct saving of analysis (should remember previous location)
3. optionally can update winspec's calibration with the fit produced when you call the diagnostic method in the file menu