### PR TITLE
consolidating msquared code

### DIFF
--- a/Modules/+Sources/+msquared/EMM.m
+++ b/Modules/+Sources/+msquared/EMM.m
@@ -20,7 +20,7 @@ classdef EMM < Sources.msquared.common_invisible
         % total tunable range in THz (should be updated when crystal changed; see obj.fitted_oven)
         range = Sources.TunableLaser_invisible.c./[580,661];
     end
-    properties(SetObservable,AbortSet)
+    properties(SetObservable,GetObservable)
         fitted_oven = Prefs.Integer(1,'readonly',true,'set','set_fitted_oven',...
             'help_text','Crystal being used: 1,2,3. This also sets range');
     end
@@ -30,7 +30,7 @@ classdef EMM < Sources.msquared.common_invisible
     
     methods(Access=private)
         function obj = EMM()
-            obj.show_prefs = [obj.prefs(1:8), {'fitted_oven'}, obj.prefs(9:end)];
+            obj.show_prefs = [obj.show_prefs(1:8), {'fitted_oven'}, obj.show_prefs(9:end)];
             obj.init();
             if obj.tuning
                 dlg = msgbox('Please wait while tuning completes from previous tuning...',mfilename,'modal');

--- a/Modules/+Sources/+msquared/EMM.m
+++ b/Modules/+Sources/+msquared/EMM.m
@@ -1,11 +1,11 @@
-classdef EMM < Modules.Source & Sources.TunableLaser_invisible
+classdef EMM < Sources.msquared.common_invisible
     % EMM Mainly to implement coarse tuning and solstis resonator tuning.
     % Similar to the SolsTiS, this cannot load if the SolsTiS is loaded
     % already. It will error in loading the solstis driver.
     %
     % Do not trust any reported values! Always update status if you want to read a value.
     %
-    % When setting hwserver_ip, it is important that this class loads the
+    % When setting hwserver_host, it is important that this class loads the
     % solstis driver before the EMM in case it is in use and needs to
     % report an error instead of loading.
     %
@@ -16,48 +16,22 @@ classdef EMM < Modules.Source & Sources.TunableLaser_invisible
     % back on redundant code. Would need to consider how to overload
     % setmethods in this subclass and consider where prefs get loaded
     
-    properties(SetObservable,SetAccess=private)
-        source_on = false;  % Always assume on (cant be changed here)
-    end
     properties(SetAccess=protected)
         % total tunable range in THz (should be updated when crystal changed; see obj.fitted_oven)
         range = Sources.TunableLaser_invisible.c./[580,661];
     end
     properties(SetObservable,AbortSet)
-        tuning = false;
-        hwserver_ip = Sources.msquared.EMM.no_server;
-        resonatorVoltageToPercentCalibration = [-0.000425732939240   0.599558121753631  -5.361161084160642]; %second order polynomial
-        fitted_oven = 1;        % Readable (crystal being used: 1,2,3). This also sets range
-        etalon_percent = 0;  % Settable
-        etalon_voltage = 0;  % Readable
-        etalon_lock = false;  % Settable
-        resonator_percent = 0;  % Settable
-        resonator_voltage = 0;  % Readable
-        target_wavelength = 0; % nm settable
-        wavelength_lock = false; % settable (so this is necessary ontop of "locked")
-        resonator_tune_speed = 0.5; % percent per step
-        PBline = 1; % Indexed from 1
-        pb_ip = Sources.msquared.EMM.no_server;
-        prefs = {'hwserver_ip','PBline','pb_ip','resonator_tune_speed'};
-        show_prefs = {'tuning','target_wavelength','wavelength_lock','etalon_lock','fitted_oven','resonator_percent','resonator_voltage','etalon_percent','etalon_voltage','hwserver_ip','PBline','pb_ip','resonator_tune_speed'};
-        readonly_prefs = {'tuning','fitted_oven','resonator_voltage','etalon_voltage'};
+        fitted_oven = Prefs.Integer(1,'readonly',true,'set','set_fitted_oven',...
+            'help_text','Crystal being used: 1,2,3. This also sets range');
     end
-    properties(Access=private)
-        PulseBlaster  % handle to PulseBlaster Driver
-        solstisHandle % handle to Solstis Driver
+    properties(Access=protected)
         emmHandle     % handle to EMM driver
-        timeout = 30;
-    end
-    properties(Constant,Hidden)
-        no_server = 'No Server';  % Message when not connected
     end
     
     methods(Access=private)
         function obj = EMM()
-            obj.hwserver_ip = obj.no_server; % Default value (overriden in loadPrefs if saved)
-            obj.pb_ip = obj.no_server; % Default value (overriden in loadPrefs if saved)
-            obj.loadPrefs;  % This will call set.(*_ip) too which instantiate hardware
-            obj.updateStatus(); % Redundant with set.(*_ip) but useful for if no ip pref
+            obj.show_prefs = [obj.prefs(1:8), {'fitted_oven'}, obj.prefs(9:end)];
+            obj.init();
             if obj.tuning
                 dlg = msgbox('Please wait while tuning completes from previous tuning...',mfilename,'modal');
                 try
@@ -77,32 +51,6 @@ classdef EMM < Modules.Source & Sources.TunableLaser_invisible
                 delete(dlg)
             end
         end
-        function err = connect_driver(obj,propname,drivername,varargin)
-            err = [];
-            if ~isempty(obj.(propname))
-                delete(obj.(propname)); %remove any old connection
-            end
-            if ischar(varargin{1}) && strcmpi(varargin{1},obj.no_server) %first input is always an ip address
-                obj.(propname) = [];
-            else
-                try
-                    obj.(propname) = Drivers.(drivername).instance(varargin{:});
-                catch err
-                    obj.(propname) = [];
-                end
-            end
-        end
-        function tf = internal_call(obj)
-            tf = false; % Assume false, verify that true later
-            st = dbstack(2);  % Exclude this method, and its caller
-            if ~isempty(st)
-                caller_class = strsplit(st(1).name,'.');
-                caller_class = caller_class{1};
-                this_class = strsplit(class(obj),'.');
-                this_class = this_class{end};
-                tf = strcmp(this_class,caller_class);
-            end
-        end
     end
     methods(Static)
         function obj = instance()
@@ -119,90 +67,21 @@ classdef EMM < Modules.Source & Sources.TunableLaser_invisible
             obj.emmHandle.ready;
         end
         function updateStatus(obj)
-            % Get status report from laser and update a few fields
-            % This kills man-in-the-middle!!
-            if strcmp(obj.hwserver_ip,obj.no_server)
-                obj.locked = false; %NaN; logical cannot be NaN or creation of the ui is failing
-                obj.etalon_lock = false;
-                obj.etalon_voltage = NaN;
-                obj.resonator_voltage = NaN;
-                obj.wavelength_lock = false; %NaN;
-                obj.fitted_oven = NaN;
-            else
-                reply = obj.solstisHandle.getStatus();
-                obj.etalon_lock = strcmp(reply.etalon_lock,'on');
-                obj.etalon_voltage = reply.etalon_voltage;
-                obj.resonator_voltage = reply.resonator_voltage;
-                obj.getWavelength; % This sets wavelength_lock
-                
+            % Common gets solstis stuff
+            updateStatus@Sources.msquared.common_invisible(obj)
+            % Now get EMM stuff. This kills man-in-the-middle!!
+            if ~strcmp(obj.hwserver_host,obj.no_server)
                 reply = obj.emmHandle.getStatus();
                 obj.fitted_oven = reply.fitted_oven;
                 obj.tuning = strcmp(reply.tuning,'active'); % Overwrite getWavelength tuning status with EMM tuning state
             end
-        end
-        
-        function on(obj)
-            assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
-            obj.PulseBlaster.lines(obj.PBline) = true;
-            obj.source_on = true;
-        end
-        function off(obj)
-            assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
-            obj.source_on = false;
-            obj.PulseBlaster.lines(obj.PBline) = false;
-        end
-        
-        function delete(obj)
-            errs = {};
-            try
-                if ~isempty(obj.solstisHandle)
-                    delete(obj.solstisHandle);
-                end
-            catch err
-                errs{end+1} = err.message;
-            end
-            try % Cleaning this up second should leave hwserver in EMM state (e.g. MITM spawned)
-                if ~isempty(obj.emmHandle)
-                    delete(obj.emmHandle);
-                end
-            catch err
-                errs{end+1} = err.message;
-            end
-            if ~isempty(errs)
-                error('Error(s) cleaning up EMM:\n%s',strjoin(errs,newline))
-            end
-        end
-        
-        function [wavelength] = getWavelength(obj)
-            % Use solstis handle to get wavelength
-            % Attempt to get non-error value until timeout
-            t = tic;
-            while true
-                try
-                    [wavelength,lock,istuning] = obj.solstisHandle.getWavelength();
-                    break
-                catch err
-                    if toc(t) > obj.timeout
-                        rethrow(err)
-                    end
-                end
-            end
-            obj.setpoint = obj.c/wavelength;
-            obj.tuning = istuning;
-            obj.wavelength_lock = lock;
-            obj.locked = lock;
-        end
-        
-        function resonatorPercent = resonatorVoltageToPercent(obj,voltage)
-            resonatorPercent = obj.resonatorVoltageToPercentCalibration(1)*voltage^2 ...
-                +obj.resonatorVoltageToPercentCalibration(2)*voltage+obj.resonatorVoltageToPercentCalibration(3);
         end
         function tune(obj,target)
             % This is the tuning method that interacts with hardware
             % (potentially a very expensive operation if switching from
             % solstis)
             % target in nm
-            assert(~isempty(obj.emmHandle)&&isobject(obj.emmHandle) && isvalid(obj.emmHandle),'no emmHandle, check hwserver_ip')
+            assert(~isempty(obj.emmHandle)&&isobject(obj.emmHandle) && isvalid(obj.emmHandle),'no emmHandle, check hwserver_host')
             assert(target>=obj.c/max(obj.range)&&target<=obj.c/min(obj.range),sprintf('Wavelength must be in range [%g, %g] nm!!',obj.c./obj.range))
             err = [];
             % The EMM blocks during tuning, so message is useful until a non-blocking operation exists
@@ -233,59 +112,35 @@ classdef EMM < Modules.Source & Sources.TunableLaser_invisible
             obj.wavelength_lock = true;
             obj.etalon_lock = true;  % We don't know at this point anything about etalon if not locked
         end
-        
-        function WavelengthLock(obj,lock)
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(islogical(lock)||lock==0||lock==1,'lock must be true/false')
-            if lock
-                strlock = 'on';
-            else
-                strlock = 'off';
+
+        function delete(obj)
+            errs = {};
+            try
+                if ~isempty(obj.solstisHandle)
+                    delete(obj.solstisHandle);
+                end
+            catch err
+                errs{end+1} = err.message;
             end
-            obj.solstisHandle.lock_wavelength(strlock);
-            obj.tuning = true;
-            pause(1) % Wait for msquared to start tuning
-            obj.trackFrequency; % Will block until obj.tuning = false (calling obj.getFrequency)
-            obj.updateStatus(); % Resonator, etalon both changed after tune
-        end
-        
-        % tunable laser methods
-        function freq = getFrequency(obj)
-            wavelength = obj.getWavelength;
-            freq = obj.c/wavelength;
-        end
-        function TuneCoarse(obj,target)
-            obj.tune(obj.c/target);
-            if obj.locked
-                pause(3); % Required for the EMM to reach the target wavelength
-                obj.WavelengthLock(false);
+            try % Cleaning this up second should leave hwserver in EMM state (e.g. MITM spawned)
+                if ~isempty(obj.emmHandle)
+                    delete(obj.emmHandle);
+                end
+            catch err
+                errs{end+1} = err.message;
             end
-        end
-        function TuneSetpoint(obj,target) % THz
-            obj.tune(obj.c/target);
-        end
-        function TunePercent(obj,target)
-            % This is the solstis resonator
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(target>=0&&target<=100,'Target must be a percentage')
-            % tune at a limited rate per step
-            currentPercent = obj.GetPercent;
-            numberSteps = floor(abs(currentPercent-target)/obj.resonator_tune_speed);
-            direction = sign(target-currentPercent);
-            for i = 1:numberSteps
-                obj.solstisHandle.set_resonator_percent(currentPercent+(i)*direction*obj.resonator_tune_speed);
+            if ~isempty(errs)
+                error('Error(s) cleaning up EMM:\n%s',strjoin(errs,newline))
             end
-            obj.solstisHandle.set_resonator_percent(target);
-            obj.resonator_percent = target;
-            obj.updateStatus(); % Get voltage of resonator
         end
         
         % Set methods
-        function set.hwserver_ip(obj,ip)
+        function set_hwserver_host(obj,host)
+            if isempty(host); return; end % Short circuit on empty hostname
             % solstis
-            err = obj.connect_driver('solstisHandle','msquared.solstis',ip);
+            err = obj.connect_driver('solstisHandle','msquared.solstis',host);
             if ~isempty(err)
-                obj.hwserver_ip = obj.no_server;
+                obj.hwserver_host = obj.no_server;
                 obj.updateStatus();
                 if contains(err.message,'driver is already instantiated')
                     error('solstis driver already instantiated. Likely due to an active SolsTiS source; please close it and retry.')
@@ -293,61 +148,19 @@ classdef EMM < Modules.Source & Sources.TunableLaser_invisible
                 rethrow(err)
             end
             % EMM (if here, we can assume solstis loaded correctly)
-            err = obj.connect_driver('emmHandle','msquared.EMM',ip);
+            err = obj.connect_driver('emmHandle','msquared.EMM',host);
             if ~isempty(err)
-                obj.hwserver_ip = obj.no_server;
+                obj.hwserver_host = obj.no_server;
                 obj.updateStatus();
                 delete(obj.solstisHandle);
                 obj.solstisHandle = [];
                 error('solstis loaded, but EMM failed. Solstis handle destroyed:\n%s',err.message);
             end
             % Can only get here if both successful
-            obj.hwserver_ip = ip;
+            obj.hwserver_host = host;
             obj.updateStatus();
         end
-        function set.target_wavelength(obj,val)
-            if isnan(val); obj.target_wavelength = val; return; end % Short circuit on NaN
-            if obj.internal_call; obj.target_wavelength = val; return; end
-            obj.tune(val);
-        end
-        function percent = GetPercent(obj)
-                obj.updateStatus();
-                percent =  obj.resonatorVoltageToPercent(obj.resonator_voltage);
-        end
-        function set.wavelength_lock(obj,val)
-            if isnan(val); obj.wavelength_lock = val; return; end % Short circuit on NaN
-            if obj.internal_call; obj.wavelength_lock = val; return; end
-            obj.WavelengthLock(val);
-        end
-        function set.resonator_percent(obj,val)
-            if isnan(val); obj.resonator_percent = val; return; end % Short circuit on NaN
-            if obj.internal_call; obj.resonator_percent = val; return; end
-            obj.TunePercent(val);
-        end
-        function set.etalon_percent(obj,val)
-            if isnan(val); obj.etalon_percent = val; return; end % Short circuit on NaN
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(val>=0&&val<=100,'Value must be a percentage')
-            if obj.internal_call; obj.etalon_percent = val; return; end
-            obj.solstisHandle.set_etalon_percent(val);
-            obj.etalon_percent = val;
-            obj.updateStatus(); % Update the value of the voltage
-        end
-        function set.etalon_lock(obj,val)
-            % Changing etalon lock changes resonator too
-            if isnan(val); obj.etalon_lock = val; return; end % Short circuit on NaN
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(islogical(val)||val==0||val==1,'Value must be true/false')
-            if obj.internal_call; obj.etalon_lock = val; return; end
-            if val
-                strval = 'on';
-            else
-                strval = 'off';
-            end
-            obj.solstisHandle.set_etalon_lock(strval);
-            obj.etalon_lock = val;
-        end
-        function set.fitted_oven(obj,val)
+        function val = set_fitted_oven(obj,val,~)
             if isnan(val); obj.fitted_oven = val; return; end % Short circuit on NaN
             obj.fitted_oven = val;
             % Update range
@@ -360,43 +173,7 @@ classdef EMM < Modules.Source & Sources.TunableLaser_invisible
                     obj.range = NaN(1,2);
                     error('Unknown fitted_oven id (cannot set range): %i',val)
             end
-            
         end
-        function updateCalibration(obj,range)
-            for i = 1:length(range)
-                obj.TunePercent(range(i));
-                pause(0.1)
-                obj.updateStatus;
-                voltages(i) = obj.resonator_voltage;
-            end
-            ft = fittype( 'poly2' );
-            opts = fitoptions( 'Method', 'LinearLeastSquares' );
-            [fitresult, gof] = fit( voltages, range, ft, opts );
-            obj.resonatorVoltageToPercentCalibration = coeffvalues(fitresult);
-        end
-        
-        %PB methods
-        function set.pb_ip(obj,ip)
-            err = obj.connect_driver('PulseBlaster','PulseBlaster.StaticLines',ip);
-            if isempty(obj.PulseBlaster)
-                obj.pb_ip = obj.no_server;
-            else
-                obj.pb_ip = ip;
-                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
-            end
-            if ~isempty(err)
-                rethrow(err)
-            end
-        end
-        
-        function set.PBline(obj,val)
-            assert(round(val)==val&&val>0,'PBline is indexed from 1.')
-            obj.PBline = val;
-            if ~isempty(obj.PulseBlaster)
-                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
-            end
-        end
-        
     end
 end
 

--- a/Modules/+Sources/+msquared/SolsTiS.m
+++ b/Modules/+Sources/+msquared/SolsTiS.m
@@ -1,4 +1,4 @@
-classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
+classdef SolsTiS < Sources.msquared.common_invisible
     %SOLSTIS Control parts of SolsTis (msquared) laser
     %   Talks via the hwserver (via the driver)
     %   All methods go through a set.method to perform operation
@@ -17,75 +17,13 @@ classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
     %   - updateStatus at the end of the set methods may be executed before
     %       the operation on the laser has finished (setting outdated values)
 
-    properties
-        timeout = 1; % Ignore errors within this timeout on wavelength read (used in getWavelength)
-    end
-    properties(SetObservable,SetAccess=private)
-        source_on = false;  % Always assume on (cant be changed here)
-    end
     properties(SetAccess=protected)
         range = Sources.TunableLaser_invisible.c./[700,1000]; %tunable range in THz
-    end
-    properties(SetObservable,AbortSet)
-        resVolt2Percent = struct('fcn',cfit(),'gof',[],'datetime',[]);
-        calibrateRes = false; % Interface to request calibration
-        tuning = false;
-        hwserver_ip = Sources.msquared.SolsTiS.no_server;
-        etalon_percent = 0;  % Settable
-        etalon_voltage = 0;  % Readable
-        etalon_lock = false;  % Settable
-        resonator_percent = 0;  % Settable
-        resonator_voltage = 0;  % Readable
-        target_wavelength = 0; % nm settable
-        wavelength_lock = false; % Settable
-        PBline = 1; % Indexed from 1
-        resonator_tune_speed = 2; % percent per step
-        pb_ip = Sources.msquared.SolsTiS.no_server;
-        prefs = {'hwserver_ip','PBline','pb_ip','resonator_tune_speed','resVolt2Percent'};
-        show_prefs = {'tuning','target_wavelength','wavelength_lock','etalon_lock','resonator_percent','resonator_voltage',...
-            'etalon_percent','etalon_voltage','hwserver_ip','PBline','pb_ip','resonator_tune_speed','calibrateRes'};
-        readonly_prefs = {'tuning','resonator_voltage','etalon_voltage'};
-    end
-    properties(Access=private)
-        PulseBlaster   % handle to PulseBlaster Driver
-        solstisHandle % handle to Solstis Driver
-    end
-    properties(Constant,Hidden)
-        no_server = 'No Server';  % Message when not connected
     end
     
     methods(Access=private)
         function obj = SolsTiS()
-            obj.hwserver_ip = obj.no_server; % Default value (overriden in loadPrefs if saved)
-            obj.pb_ip = obj.no_server; % Default value (overriden in loadPrefs if saved)
-            obj.loadPrefs;  % This will call set.(*_ip) too which instantiate hardware
-            obj.updateStatus();
-        end
-        function err = connect_driver(obj,propname,drivername,varargin)
-            err = [];
-            if ~isempty(obj.(propname))
-                delete(obj.(propname)); %remove any old connection
-            end
-            if ischar(varargin{1}) && strcmpi(varargin{1},obj.no_server) %first input is always an ip address
-                obj.(propname) = [];
-            else
-                try
-                    obj.(propname) = Drivers.(drivername).instance(varargin{:});
-                catch err
-                    obj.(propname) = [];
-                end
-            end
-        end
-        function tf = internal_call(obj)
-            tf = false; % Assume false, verify that true later
-            st = dbstack(2);  % Exclude this method, and its caller
-            if ~isempty(st)
-                caller_class = strsplit(st(1).name,'.');
-                caller_class = caller_class{1};
-                this_class = strsplit(class(obj),'.');
-                this_class = this_class{end};
-                tf = strcmp(this_class,caller_class);
-            end
+            obj.init();
         end
     end
     methods(Static)
@@ -99,120 +37,16 @@ classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
         end
     end
     methods
-        function updateStatus(obj)
-            % Get status report from laser and update a few fields
-            if strcmp(obj.hwserver_ip,obj.no_server)
-                obj.etalon_lock = false; %NaN; logical cannot be NaN or creation of the ui is failing
-                obj.locked = false; %NaN;
-                obj.etalon_voltage = NaN;
-                obj.resonator_voltage = NaN;
-                obj.wavelength_lock = false; %NaN;
-                obj.setpoint = NaN;
-            else
-                reply = obj.solstisHandle.getStatus();
-                obj.etalon_lock = strcmp(reply.etalon_lock,'on');
-                obj.etalon_voltage = reply.etalon_voltage;
-                obj.resonator_voltage = reply.resonator_voltage;
-                obj.getWavelength; % This sets wavelength_lock (and potentially etalon_lock)
-            end
-        end
-        function calibrate_voltageToPercent(obj)
-            if isempty(obj.solstisHandle) || ~isvalid(obj.solstisHandle)
-                error('Need to connect to SolsTiS first.')
-            end
-            obj.WavelengthLock(false);
-            % Put resonator at zero percent and wait to settle just in case
-            obj.solstisHandle.set_resonator_percent(0);
-            pause(0.5);
-            % Calls will go to driver directly since no assumptions on
-            % calibration being there or accurate yet
-            n = 101;
-            voltages = NaN(n,1);
-            percents = linspace(0,100,n)';
-            f = UseFigure('SolsTiS.calibrate_voltageToPercent',true);
-            ax = axes('parent',f); hold(ax,'on');
-            figure(f);
-            lnH = plot(ax,voltages,percents,'-o');
-            ylabel(ax,'Percent (%)');
-            xlabel(ax,'Voltage (V)');
-            tH = title(ax,'Starting Calibration');
-            for i = 1:n
-                tH.String = sprintf('Calibrating: %i/%i',i,n);
-                obj.solstisHandle.set_resonator_percent(percents(i));
-                pause(1);
-                reply = obj.solstisHandle.getStatus();
-                voltages(i) = reply.resonator_voltage;
-                lnH.XData(i) = voltages(i);
-                drawnow limitrate;
-            end
-            [ft,gof] = fit(voltages,percents,'poly2');
-            tH.String = sprintf('adjR^2: %g',gof.adjrsquare);
-            plotV = linspace(min(voltages),max(voltages),1001);
-            fitbounds = predint(ft,plotV,0.95,'functional','on'); %get confidence bounds on fit
-            errorfill(plotV,ft(plotV),[abs(ft(plotV)'-fitbounds(:,1)');abs(fitbounds(:,2)'-ft(plotV)')],'parent',ax);
-            subplot(2,1,1,ax);
-            ax_resid = subplot(2,1,2,'parent',f);
-            plot(ax_resid,voltages,percents-ft(voltages),'-o');
-            ylabel(ax_resid,'Percent (%)');
-            xlabel(ax_resid,'Voltage (V)');
-            title(ax_resid,'Residuals');
-            answer = questdlg('Calibration satisfactory?','SolsTiS Resonator Calibration Verification','Yes','No, abort','Yes');
-            if strcmp(answer,'No, abort')
-                error('Failed SolsTiS resonator calibration validation.')
-            end
-            obj.resVolt2Percent.fcn = ft;
-            obj.resVolt2Percent.gof = gof;
-            obj.resVolt2Percent.datetime = datetime;
-        end
-        
-        function on(obj)
-            assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
-            obj.PulseBlaster.lines(obj.PBline) = true;
-            obj.source_on = true;
-        end
-        function off(obj)
-            assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
-            obj.source_on = false;
-            obj.PulseBlaster.lines(obj.PBline) = false;
-        end
-        function percent = GetPercent(obj)
-            if isempty(obj.resVolt2Percent.fcn)
-                error('Calibrate resonator first. Click "calibrateRes" setting or call "calibrate_voltageToPercent".');
-            end
-            obj.updateStatus();
-            percent = obj.resVolt2Percent.fcn(obj.resonator_voltage);
-        end
         function delete(obj)
             if ~isempty(obj.solstisHandle)
                 delete(obj.solstisHandle);
             end
         end
-        function [wavelength] = getWavelength(obj)
-            % Attempt to get non-error value until timeout
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            t = tic;
-            while true
-                try
-                    [wavelength,lock,istuning] = obj.solstisHandle.getWavelength();
-                    break
-                catch err
-                    if toc(t) > obj.timeout
-                        rethrow(err)
-                    end
-                end
-            end
-            obj.setpoint = obj.c/wavelength;
-            obj.tuning = istuning;
-            obj.wavelength_lock = lock;
-            obj.locked = lock;
-            if lock
-                obj.etalon_lock = true;
-            end
-        end
+
         function tune(obj,target)
             % This is the tuning method that interacts with hardware
             % target in nm
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
             assert(target>obj.c/max(obj.range)&&target<obj.c/min(obj.range),sprintf('Wavelength must be in range [%g, %g] nm!!',obj.c./obj.range))
             obj.solstisHandle.set_target_wavelength(target);
             obj.target_wavelength = target;
@@ -222,72 +56,12 @@ classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
             obj.updateStatus();
         end
         
-        % tunable laser methods
-        function freq = getFrequency(obj)
-            wavelength = obj.getWavelength;
-            freq = obj.c/wavelength;
-        end
-        function TuneCoarse(obj,target)
-            obj.tune(obj.c/target);
-            if obj.locked
-                obj.WavelengthLock(false);
-            end
-        end
-        function TuneSetpoint(obj,target) % THz
-            obj.tune(obj.c/target);
-        end
-        function TunePercent(obj,target)
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(target>=0&&target<=100,'Target must be a percentage')
-            % tune at a limited rate per step
-            currentPercent = obj.GetPercent;
-            numberSteps = floor(abs(currentPercent-target)/obj.resonator_tune_speed);
-            direction = sign(target-currentPercent);
-            for i = 1:numberSteps
-                obj.solstisHandle.set_resonator_percent(currentPercent+(i)*direction*obj.resonator_tune_speed);
-            end
-            obj.solstisHandle.set_resonator_percent(target);
-            obj.resonator_percent = target;
-            obj.updateStatus(); % Get voltage
-        end
-        
-        function WavelengthLock(obj,lock)
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(islogical(lock)||lock==0||lock==1,'lock must be true/false')
-            if lock
-                strlock = 'on';
-            else
-                strlock = 'off';
-            end
-            obj.solstisHandle.lock_wavelength(strlock);
-            obj.tuning = true;
-            pause(1) % Wait for msquared to start tuning
-            obj.trackFrequency; % Will block until obj.tuning = false (calling obj.getFrequency)
-            obj.wavelength_lock = lock;
-            obj.updateStatus(); % Get resonator/etalon
-        end
-        function EtalonLock(obj,lock)
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(islogical(lock)||lock==0||lock==1,'lock must be true/false')
-            if lock
-                lock = 'on';
-            else
-                lock = 'off';
-            end
-            obj.solstisHandle.set_etalon_lock(lock);
-        end
-        
         % Set methods
-        function set.calibrateRes(obj,~)
-            % Check mark used to call calibration method
-            obj.calibrate_voltageToPercent();
-            obj.calibrateRes = false;
-        end
-        function set.hwserver_ip(obj,ip)
-            if isempty(ip); return; end % Short circuit on empty IP
-            err = obj.connect_driver('solstisHandle','msquared.solstis',ip);
+        function set_hwserver_host(obj,host)
+            if isempty(host); return; end % Short circuit on empty hostname
+            err = obj.connect_driver('solstisHandle','msquared.solstis',host);
             if ~isempty(err)
-                obj.hwserver_ip = obj.no_server;
+                obj.hwserver_host = obj.no_server;
                 obj.updateStatus();
                 if contains(err.message,'driver is already instantiated')
                     error('solstis driver already instantiated. Likely due to an active EMM source; please close it and retry.')
@@ -296,69 +70,9 @@ classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
             end
             range = obj.solstisHandle.get_wavelength_range; %#ok<*PROPLC> % solstis hardware handle
             obj.range = obj.c./[range.minimum_wavelength, range.maximum_wavelength];
-            obj.hwserver_ip = ip;
+            obj.hwserver_host = host;
             obj.updateStatus();
         end
-        function set.target_wavelength(obj,val)
-            if isnan(val); obj.target_wavelength = val; return; end % Short circuit on NaN
-            if obj.internal_call; obj.target_wavelength = val; return; end
-            obj.tune(val);
-        end
-        function set.wavelength_lock(obj,val)
-            if isnan(val); obj.wavelength_lock = val; return; end % Short circuit on NaN
-            if obj.internal_call; obj.wavelength_lock = val; return; end
-            obj.WavelengthLock(val);
-        end
-        function set.resonator_percent(obj,val)
-            if isnan(val); obj.resonator_percent = val; return; end % Short circuit on NaN
-            if obj.internal_call; obj.resonator_percent = val; return; end
-            obj.TunePercent(val);
-        end
-        % Set methods without parent method to interact with hardware
-        function set.etalon_percent(obj,val)
-            if isnan(val); obj.etalon_percent = val; return; end % Short circuit on NaN
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(val>=0&&val<=100,'Value must be a percentage')
-            if obj.internal_call; obj.etalon_percent = val; return; end
-            obj.solstisHandle.set_etalon_percent(val);
-            obj.etalon_percent = val;
-            obj.updateStatus();
-        end
-        function set.etalon_lock(obj,val)
-            % Changing etalon lock changes resonator too
-            if isnan(val); obj.etalon_lock = val; return; end % Short circuit on NaN
-            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_ip')
-            assert(islogical(val)||val==0||val==1,'Value must be true/false')
-            if obj.internal_call; obj.etalon_lock = val; return; end
-            if val
-                strval = 'on';
-            else
-                strval = 'off';
-            end
-            obj.solstisHandle.set_etalon_lock(strval);
-            obj.etalon_lock = val;
-            obj.updateStatus();
-        end
-        
-        %PB methods
-        function set.pb_ip(obj,ip)
-            err = obj.connect_driver('PulseBlaster','PulseBlaster.StaticLines',ip);
-            if ~isempty(err)
-                obj.pb_ip = obj.no_server;
-                rethrow(err)
-            end
-            obj.pb_ip = ip;
-            obj.source_on = obj.PulseBlaster.lines(obj.PBline);
-        end
-        
-        function set.PBline(obj,val)
-            assert(round(val)==val&&val>0,'PBline is indexed from 1.')
-            obj.PBline = val;
-            if ~isempty(obj.PulseBlaster)
-                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
-            end
-        end
-
     end
 end
 

--- a/Modules/+Sources/+msquared/SolsTiS.m
+++ b/Modules/+Sources/+msquared/SolsTiS.m
@@ -123,12 +123,30 @@ classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
             n = 101;
             voltages = NaN(n,1);
             percents = linspace(0,100,n)';
+            f = UseFigure('SolsTiS.calibrate_voltageToPercent',true);
+            ax = axes('parent',f); hold(ax,'on');
+            figure(f);
+            lnH = plot(ax,voltages,percents,'-o');
+            ylabel(ax,'Percent (%)');
+            xlabel(ax,'Voltage (V)');
+            tH = title(ax,'Starting Calibration');
             for i = 1:n
-                obj.solstisHandle.set_resonator_percent(percents(i));
-                reply = obj.solstisHandle.getStatus();
-                voltages(i) = reply.resonator_voltage;
+                tH.String = sprintf('Calibrating: %i/%i',i,n);
+               % obj.solstisHandle.set_resonator_percent(percents(i));
+               % reply = obj.solstisHandle.getStatus();
+               % voltages(i) = reply.resonator_voltage;
+                voltages(i) = rand(1);
+                lnH.XData(i) = voltages(i);
+                drawnow limitrate;
             end
             ft = fit(voltages,percents,'poly2');
+            plotV = linspace(min(voltages),max(voltages),1001);
+            fitbounds = predint(ft,plotV,0.95,'functional','on'); %get confidence bounds on fit
+            errorfill(plotV,ft(plotV),[abs(ft(plotV)'-fitbounds(:,1)');abs(fitbounds(:,2)'-ft(plotV)')],'parent',ax);
+            answer = questdlg('Calibration satisfactory?','SolsTiS Resonator Calibration Verification','Yes','No, abort','Yes');
+            if strcmp(answer,'No, abort')
+                error('Failed SolsTiS resonator calibration validation.')
+            end
             obj.resVolt2Percent = ft;
         end
         

--- a/Modules/+Sources/+msquared/SolsTiS.m
+++ b/Modules/+Sources/+msquared/SolsTiS.m
@@ -49,15 +49,17 @@ classdef SolsTiS < Sources.msquared.common_invisible
             assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
             assert(target>obj.c/max(obj.range)&&target<obj.c/min(obj.range),sprintf('Wavelength must be in range [%g, %g] nm!!',obj.c./obj.range))
             obj.solstisHandle.set_target_wavelength(target);
-            obj.target_wavelength = target;
-            obj.tuning = true;
+            obj.updatingVal = true;
+                obj.target_wavelength = target;
+                obj.tuning = true;
+            obj.updatingVal = false;
             pause(1) % Wait for msquared to start tuning
             obj.trackFrequency(obj.c/target); % Will block until obj.tuning = false (calling obj.getFrequency)
             obj.updateStatus();
         end
         
         % Set methods
-        function set_hwserver_host(obj,host)
+        function host = set_hwserver_host(obj,host,~)
             if isempty(host); return; end % Short circuit on empty hostname
             err = obj.connect_driver('solstisHandle','msquared.solstis',host);
             if ~isempty(err)
@@ -70,7 +72,6 @@ classdef SolsTiS < Sources.msquared.common_invisible
             end
             range = obj.solstisHandle.get_wavelength_range; %#ok<*PROPLC> % solstis hardware handle
             obj.range = obj.c./[range.minimum_wavelength, range.maximum_wavelength];
-            obj.hwserver_host = host;
             obj.updateStatus();
         end
     end

--- a/Modules/+Sources/+msquared/SolsTiS.m
+++ b/Modules/+Sources/+msquared/SolsTiS.m
@@ -145,10 +145,11 @@ classdef SolsTiS < Modules.Source & Sources.TunableLaser_invisible
                 lnH.XData(i) = voltages(i);
                 drawnow limitrate;
             end
-            [ft,gof] = fit(voltages,percents,'smoothingspline');
+            [ft,gof] = fit(voltages,percents,'poly2');
             tH.String = sprintf('adjR^2: %g',gof.adjrsquare);
             plotV = linspace(min(voltages),max(voltages),1001);
-            plot(ax,plotV,ft(plotV));
+            fitbounds = predint(ft,plotV,0.95,'functional','on'); %get confidence bounds on fit
+            errorfill(plotV,ft(plotV),[abs(ft(plotV)'-fitbounds(:,1)');abs(fitbounds(:,2)'-ft(plotV)')],'parent',ax);
             subplot(2,1,1,ax);
             ax_resid = subplot(2,1,2,'parent',f);
             plot(ax_resid,voltages,percents-ft(voltages),'-o');

--- a/Modules/+Sources/+msquared/common_invisible.m
+++ b/Modules/+Sources/+msquared/common_invisible.m
@@ -1,0 +1,305 @@
+classdef(Abstract) common_invisible < Modules.Source & Sources.TunableLaser_invisible
+    % Code and methods shared by EMM and SolsTiS will be inherited from this class
+
+    properties(SetObservable,SetAccess=protected)
+        source_on = false;  % Always assume on (cant be changed here)
+    end
+    properties
+        resVolt2Percent = struct('fcn',cfit(),'gof',[],'datetime',[]);
+        prefs = {'hwserver_host','PBline','pb_host','resonator_tune_speed','resVolt2Percent'};
+        show_prefs = {'tuning','target_wavelength','wavelength_lock','etalon_lock','resonator_percent','resonator_voltage',...
+            'etalon_percent','etalon_voltage','hwserver_host','PBline','pb_host','resonator_tune_speed','calibrateRes'};
+    end
+    properties(SetObservable,GetObservable)
+        calibrateRes = Prefs.Boolean(false,'set','set_calibrateRes',...
+            'help_text','Begin resonator voltage -> percent calibration (changes resVolt2Percent).');
+        tuning = Prefs.Boolean(false,'readonly',true);
+        hwserver_host = Prefs.String(Sources.msquared.common_invisible.no_server,'set','set_hwserver_host');
+        etalon_percent = Prefs.Double(NaN,'units','%','help_text','Set etalon percent. This will change the etalon_voltage that is read.');  % Settable
+        etalon_voltage = Prefs.Double(NaN,'units','V','readonly',true);  % Readable
+        etalon_lock = Prefs.Boolean(false,'set','set_etalon_lock');  % Settable
+        resonator_percent = Prefs.Double(NaN,'units','%','min',0,'max',100,'set','set_resonator_percent',...
+            'help_text','Set resonator percent. This will change the resonator_voltage that is read.');  % Settable
+        resonator_voltage = Prefs.Double(NaN,'units','V','readonly',true);  % Readable
+        target_wavelength = Prefs.Double(NaN,'units','nm','set','set_target_wavelength'); % nm settable
+        wavelength_lock = Prefs.Boolean(false,'set','set_wavelength_lock'); % Settable
+        PBline = Prefs.Integer(1,'min',1,'set','set_PBline','help_text','Indexed from 1.');
+        pb_host = Prefs.String(Sources.msquared.common_invisible.no_server,'set','set_pb_host');
+        resonator_tune_speed = Prefs.Double(2,'units','%/step','min',0,'allow_nan',false,'help_text','Maximum % per step allowed. Lower numbers will take longer to tune.');
+    end
+    properties(Access=protected)
+        timeout = 30   % Ignore errors within this timeout on wavelength read (getWavelength)
+        PulseBlaster   % handle to PulseBlaster Driver
+        solstisHandle  % handle to Solstis Driver
+    end
+    properties(Constant,Hidden)
+        no_server = 'No Server';  % Message when not connected
+    end
+
+    methods(Access=protected)
+        function init(obj) % Call in subclass constructor
+            obj.hwserver_host = obj.no_server; % Default value (overriden in loadPrefs if saved)
+            obj.pb_host = obj.no_server; % Default value (overriden in loadPrefs if saved)
+            obj.loadPrefs;  % This will call set.(*_host) too which instantiate hardware
+            obj.updateStatus(); % Redundant with set.(*_host) but useful for if no host pref
+        end
+        function err = connect_driver(obj,propname,drivername,varargin)
+            err = [];
+            if ~isempty(obj.(propname))
+                delete(obj.(propname)); %remove any old connection
+            end
+            if ischar(varargin{1}) && strcmpi(varargin{1},obj.no_server) %first input is always an host address
+                obj.(propname) = [];
+            else
+                try
+                    obj.(propname) = Drivers.(drivername).instance(varargin{:});
+                catch err
+                    obj.(propname) = [];
+                end
+            end
+        end
+        function tf = internal_call(obj)
+            tf = false; % Assume false, verify that true later
+            st = dbstack(2);  % Exclude this method, and its caller
+            if ~isempty(st)
+                caller_class = strsplit(st(1).name,'.');
+                caller_class = caller_class{1};
+                this_class = strsplit(class(obj),'.');
+                this_class = this_class{end};
+                tf = strcmp(this_class,caller_class);
+            end
+        end
+    end
+    methods
+        function on(obj)
+            assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
+            obj.PulseBlaster.lines(obj.PBline) = true;
+            obj.source_on = true;
+        end
+        function off(obj)
+            assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
+            obj.source_on = false;
+            obj.PulseBlaster.lines(obj.PBline) = false;
+        end
+
+        function updateStatus(obj)
+            % Get status report from SolsTiS laser and update fields
+            if strcmp(obj.hwserver_host,obj.no_server)
+                obj.etalon_lock = false; %NaN; logical cannot be NaN or creation of the ui is failing
+                obj.locked = false; %NaN;
+                obj.etalon_voltage = NaN;
+                obj.resonator_voltage = NaN;
+                obj.wavelength_lock = false; %NaN;
+                obj.setpoint = NaN;
+            else
+                reply = obj.solstisHandle.getStatus();
+                obj.etalon_lock = strcmp(reply.etalon_lock,'on');
+                obj.etalon_voltage = reply.etalon_voltage;
+                obj.resonator_voltage = reply.resonator_voltage;
+                obj.getWavelength; % This sets wavelength_lock (and potentially etalon_lock)
+            end
+        end
+        function calibrate_voltageToPercent(obj)
+            if isempty(obj.solstisHandle) || ~isvalid(obj.solstisHandle)
+                error('Need to connect to SolsTiS first.')
+            end
+            obj.WavelengthLock(false);
+            % Put resonator at zero percent and wait to settle just in case
+            obj.solstisHandle.set_resonator_percent(0);
+            pause(0.5);
+            % Calls will go to driver directly since no assumptions on
+            % calibration being there or accurate yet
+            n = 101;
+            voltages = NaN(n,1);
+            percents = linspace(0,100,n)';
+            f = UseFigure('SolsTiS.calibrate_voltageToPercent',true);
+            ax = axes('parent',f); hold(ax,'on');
+            figure(f);
+            lnH = plot(ax,voltages,percents,'-o');
+            ylabel(ax,'Percent (%)');
+            xlabel(ax,'Voltage (V)');
+            tH = title(ax,'Starting Calibration');
+            for i = 1:n
+                tH.String = sprintf('Calibrating: %i/%i',i,n);
+                obj.solstisHandle.set_resonator_percent(percents(i));
+                pause(1);
+                reply = obj.solstisHandle.getStatus();
+                voltages(i) = reply.resonator_voltage;
+                lnH.XData(i) = voltages(i);
+                drawnow limitrate;
+            end
+            [ft,gof] = fit(voltages,percents,'poly2');
+            tH.String = sprintf('adjR^2: %g',gof.adjrsquare);
+            plotV = linspace(min(voltages),max(voltages),1001);
+            fitbounds = predint(ft,plotV,0.95,'functional','on'); %get confidence bounds on fit
+            errorfill(plotV,ft(plotV),[abs(ft(plotV)'-fitbounds(:,1)');abs(fitbounds(:,2)'-ft(plotV)')],'parent',ax);
+            subplot(2,1,1,ax);
+            ax_resid = subplot(2,1,2,'parent',f);
+            plot(ax_resid,voltages,percents-ft(voltages),'-o');
+            ylabel(ax_resid,'Percent (%)');
+            xlabel(ax_resid,'Voltage (V)');
+            title(ax_resid,'Residuals');
+            answer = questdlg('Calibration satisfactory?','SolsTiS Resonator Calibration Verification','Yes','No, abort','Yes');
+            if strcmp(answer,'No, abort')
+                error('Failed SolsTiS resonator calibration validation.')
+            end
+            obj.resVolt2Percent.fcn = ft;
+            obj.resVolt2Percent.gof = gof;
+            obj.resVolt2Percent.datetime = datetime;
+        end
+        function percent = GetPercent(obj)
+            if isempty(obj.resVolt2Percent.fcn)
+                error('Calibrate resonator first. Click "calibrateRes" setting or call "calibrate_voltageToPercent".');
+            end
+            obj.updateStatus();
+            percent = obj.resVolt2Percent.fcn(obj.resonator_voltage);
+        end
+        function [wavelength] = getWavelength(obj)
+            % Attempt to get non-error value until timeout
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
+            t = tic;
+            while true
+                try
+                    [wavelength,lock,istuning] = obj.solstisHandle.getWavelength();
+                    break
+                catch err
+                    if toc(t) > obj.timeout
+                        rethrow(err)
+                    end
+                end
+            end
+            obj.setpoint = obj.c/wavelength;
+            obj.tuning = istuning;
+            obj.wavelength_lock = lock;
+            obj.locked = lock;
+            if lock
+                obj.etalon_lock = true;
+            end
+        end
+        function tune(~,~)
+            % This is specific per device and should be overloaded
+            error('Not Implemented')
+        end
+        function WavelengthLock(obj,lock)
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
+            assert(islogical(lock)||lock==0||lock==1,'lock must be true/false')
+            if lock
+                strlock = 'on';
+            else
+                strlock = 'off';
+            end
+            obj.solstisHandle.lock_wavelength(strlock);
+            obj.tuning = true;
+            pause(1) % Wait for msquared to start tuning
+            obj.trackFrequency; % Will block until obj.tuning = false (calling obj.getFrequency)
+            obj.updateStatus(); % Resonator, etalon both changed after tune
+        end
+        function EtalonLock(obj,lock)
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
+            assert(islogical(lock)||lock==0||lock==1,'lock must be true/false')
+            if lock
+                lock = 'on';
+            else
+                lock = 'off';
+            end
+            obj.solstisHandle.set_etalon_lock(lock);
+        end
+
+        % tunable laser methods
+        function freq = getFrequency(obj)
+            wavelength = obj.getWavelength;
+            freq = obj.c/wavelength;
+        end
+        function TuneCoarse(obj,target)
+            obj.tune(obj.c/target);
+            if obj.locked
+                pause(3); % Required for the EMM to reach the target wavelength
+                obj.WavelengthLock(false);
+            end
+        end
+        function TuneSetpoint(obj,target) % THz
+            obj.tune(obj.c/target);
+        end
+        function TunePercent(obj,target)
+            % This is the solstis resonator
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
+            assert(target>=0&&target<=100,'Target must be a percentage')
+            % tune at a limited rate per step
+            currentPercent = obj.GetPercent;
+            numberSteps = floor(abs(currentPercent-target)/obj.resonator_tune_speed);
+            direction = sign(target-currentPercent);
+            for i = 1:numberSteps
+                obj.solstisHandle.set_resonator_percent(currentPercent+(i)*direction*obj.resonator_tune_speed);
+            end
+            obj.solstisHandle.set_resonator_percent(target);
+            obj.resonator_percent = target;
+            obj.updateStatus(); % Get voltage of resonator
+        end
+    end
+    
+    methods % Set methods
+        function val = set_calibrateRes(obj,~,~)
+            % Check mark used to call calibration method
+            obj.calibrate_voltageToPercent();
+            val = false;
+        end
+        function val = set_hwserver_host(~,val,~)
+            % This is specific per device and should be overloaded
+            error('Not Implemented')
+        end
+        function val = set_etalon_percent(obj,val,~)
+            if isnan(val); return; end % Short circuit on NaN
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
+            if obj.internal_call; return; end
+            obj.solstisHandle.set_etalon_percent(val);
+            obj.updateStatus();
+        end
+        function val = set_etalon_lock(obj,val,~)
+            % Changing etalon lock changes resonator too
+            if isnan(val); return; end % Short circuit on NaN
+            assert(~isempty(obj.solstisHandle)&&isobject(obj.solstisHandle) && isvalid(obj.solstisHandle),'no solstisHandle, check hwserver_host')
+            assert(islogical(val)||val==0||val==1,'Value must be true/false')
+            if obj.internal_call; return; end
+            if val
+                strval = 'on';
+            else
+                strval = 'off';
+            end
+            obj.solstisHandle.set_etalon_lock(strval);
+            obj.updateStatus();
+        end
+        function val = set_resonator_percent(obj,val,~)
+            if isnan(val); return; end % Short circuit on NaN
+            if obj.internal_call; return; end
+            obj.TunePercent(val);
+        end
+        function val = set_target_wavelength(obj,val,~)
+            if isnan(val); return; end % Short circuit on NaN
+            if obj.internal_call; return; end
+            obj.tune(val);
+        end
+        function val = set_wavelength_lock(obj,val,~)
+            if isnan(val); return; end % Short circuit on NaN
+            if obj.internal_call; return; end
+            obj.WavelengthLock(val);
+        end
+
+        function val = set_PBline(obj,val,~)
+            if ~isempty(obj.PulseBlaster)
+                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
+            end
+        end
+        function host = set_pb_host(obj,host,~)
+            err = obj.connect_driver('PulseBlaster','PulseBlaster.StaticLines',host);
+            if isempty(obj.PulseBlaster)
+                host = obj.no_server;
+                obj.pb_host = host; % Set explicitly because might error below if we got here
+            else
+                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
+            end
+            if ~isempty(err)
+                rethrow(err)
+            end
+        end
+    end
+end


### PR DESCRIPTION
Wait for pull #103 before looking at this one.

Quite a few changes here but shouldn't be functionally different at all.
- Duplicate code (copy/pasted) has been consolidated. If there was a slight mismatch I did my best to determine which one looked newer/better.
- Prefs were updated to class-based prefs

Obviously moving code around is error-prone, but in the long run it will significantly reduce errors and differences in behavior between the EMM and SolsTiS.