### PR TITLE
Dev environment (dev-env branch)

### DIFF
--- a/+Base/Manager.m
+++ b/+Base/Manager.m
@@ -124,13 +124,23 @@ classdef Manager < handle
         function savePrefs(obj)
             for i = 1:numel(obj.prefs)
                 try
-                    eval(sprintf('setpref(obj.namespace,''%s'',obj.%s);',obj.prefs{i},obj.prefs{i}));
+                    setpref(obj.namespace,obj.prefs{i},obj.(obj.prefs{i}));
                 catch err
                     warning('MANAGER:save_prefs','%s',err.message)
                 end
             end
+            % Save loaded modules as strings
+            module_strs = obj.get_modules_str;
+            setpref(obj.namespace,'loaded_modules',module_strs)
         end
         function loadPrefs(obj)
+            % Load modules
+            if ispref(obj.namespace,'loaded_modules')
+                class_strs = getpref(obj.namespace,'loaded_modules');
+                obj.modules = obj.load_module_str(class_strs);
+            else
+                obj.modules = {};
+            end
             % Load prefs
             for i = 1:numel(obj.prefs)
                 if ispref(obj.namespace,obj.prefs{i})
@@ -419,7 +429,8 @@ classdef Manager < handle
         function obj = Manager(type,handles,panelHandle,popupHandle)
             obj.type = type;
             obj.handles = handles;
-            obj.namespace = strrep(class(obj),'.','_');
+            pre = getappdata(handles.figure1,'namespace_prefix');
+            obj.namespace = [pre strrep(class(obj),'.','_')];
             if nargin < 3 % "simple" manager
                 obj.log('%s %s Initialized (simple)',obj.type,mfilename)
                 return
@@ -446,25 +457,11 @@ classdef Manager < handle
             obj.log('%s %s Initialized',obj.type,mfilename)
             addlistener(obj,'modules','PostSet',@obj.master_modules_changed);
             addlistener(obj,'active_module','PostSet',@obj.master_active_module_changed);
-            if ispref(mfilename,type)
-                class_strs = getpref(mfilename,type);
-                obj.modules = obj.load_module_str(class_strs);
-            else
-                obj.modules = {};
-            end
         end
         % Destructor
         function delete(obj)
             obj.savePrefs;
-            % Save loaded
-            module_strs = obj.get_modules_str;
-            if isempty(module_strs)
-                if ispref(mfilename,obj.type)
-                    rmpref(mfilename,obj.type)
-                end
-            else
-                setpref(mfilename,obj.type,module_strs)
-            end
+            % Delete loaded module handles
             modulesTemp = obj.modules;
             for i = 1:numel(modulesTemp)
                 if ~isempty(modulesTemp{i})&&isobject(modulesTemp{i})&&isvalid(modulesTemp{i})

--- a/+Base/Module.m
+++ b/+Base/Module.m
@@ -9,7 +9,7 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
     %   If there is a Constant property "visible" and it is set to false,
     %   this will prevent CommandCenter from displaying it.
     
-    properties(Access=private)
+    properties(SetAccess=private,Hidden)
         namespace                   % Namespace for saving prefs
         prop_listeners              % Keep track of preferences in the GUI to keep updated
         StructOnObject_state = 'on';% To restore after deleting

--- a/+Base/Module.m
+++ b/+Base/Module.m
@@ -32,14 +32,15 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
         function obj = Module
             warnStruct = warning('off','MATLAB:structOnObject');
             obj.StructOnObject_state = warnStruct.state;
-            % First get namespace
-            obj.namespace = strrep(class(obj),'.','_');
-            % Second, add to global appdata if app is available
             hObject = findall(0,'name','CommandCenter');
             if isempty(hObject)
+                pre = '';
                 obj.logger = Base.Logger_console();
-                return
+            else
+                pre = getappdata(hObject,'namespace_prefix');
             end
+            obj.namespace = [pre strrep(class(obj),'.','_')];
+            if isempty(hObject); return; end
             mods = getappdata(hObject,'ALLmodules');
             obj.logger = getappdata(hObject,'logger');
             mods{end+1} = obj;

--- a/+Modules/Imaging.m
+++ b/+Modules/Imaging.m
@@ -26,20 +26,9 @@ classdef Imaging < Base.Module
     properties(Abstract)
         maxROI
     end
-    properties(Access=private)
-        namespace
-    end
     
     methods
         function obj = Imaging()
-            d = dbstack('-completenames');
-            if numel(d) > 1
-                name = strsplit(d(2).name,'.');
-                name = name{1};
-            else
-                name = mfilename;
-            end
-            obj.namespace = sprintf('Imaging_%s',name);
             if ispref(obj.namespace,'calibration')
                 obj.calibration = getpref(obj.namespace,'calibration');
             end

--- a/+Modules/Stage.m
+++ b/+Modules/Stage.m
@@ -19,9 +19,6 @@ classdef Stage < Base.Module
         yRange                  % Range in um of x axis
         zRange                  % Range in um of x axis
     end
-    properties(Access=private)
-        namespace
-    end
     properties(Constant,Hidden)
         modules_package = 'Stages';
     end
@@ -41,14 +38,6 @@ classdef Stage < Base.Module
     end
     methods
         function obj = Stage()
-%             d = dbstack('-completenames');
-%             if numel(d) > 1
-%                 name = strsplit(d(2).name,'.');
-%                 name = name{1};
-%             else
-%                 name = mfilename;
-%             end
-            obj.namespace = strrep(class(obj),'.','_');
             if ispref(obj.namespace,'calibration')
                 obj.calibration = getpref(obj.namespace,'calibration');
             end

--- a/CommandCenter.m
+++ b/CommandCenter.m
@@ -146,7 +146,7 @@ try
     setappdata(hObject,'namespace_prefix',p.Results.namespace);
     
     % Update path
-    warning('off','MATLAB:dispatcher:nameConflict');  % Overload setpref and dbquit
+    warning('off','MATLAB:dispatcher:nameConflict');  % Overloaded methods
     if ~exist(fullfile(path,'dbquit.m'),'file')
         copyfile(fullfile(path,'dbquit_disabled.m'),fullfile(path,'dbquit.m'));
     end

--- a/CommandCenter.m
+++ b/CommandCenter.m
@@ -1,7 +1,15 @@
 function varargout = CommandCenter(varargin)
-% CommandCenter debug -> will start with logger visible during launch
-% CommandCenter reset -> will remove all previously loaded modules before launching
-% Any combination of the above two will also work
+% CommandCenter
+% CommandCenter [flags]
+% CommandCenter([name,value])
+% CommandCenter([flag1],[name1,value1],[flag2],[name2,value2])
+% Flags (should be char vectors and order does not matter):
+%   debug: Sets logger to DEBUG and starts logger on startup.
+%   reset: Removes any previously loaded modules.
+% Name/Value Pairs (order of pairs does not matter). Default values in parentheses:
+%   namespace: ('') Prepend char vector to namespaces for debugging purposes.
+%
+% -> Note, order of name/value pairs and flags does not matter
 % -> Note `CommandCenter string1 string2` is equivalent to `CommandCenter('string1','string2')`
 %
 % COMMANDCENTER MATLAB code for CommandCenter.fig
@@ -114,16 +122,15 @@ try
             rethrow(err);
         end
     end
-    % Parse inputs
+    % Parse inputs flags
     assert(all(cellfun(@ischar,varargin)),'All inputs provided to CommandCenter must be strings')
     [debug,varargin] = parseInput(varargin,'debug');
     [reset,varargin] = parseInput(varargin,'reset');
+    p = inputParser();
+    p.addParameter('namespace','',@ischar);
+    p.parse(varargin{:}); % p.Results has 
     % Prepare state based on inputs
     loggerStartState = 'off';
-    if ~isempty(varargin)
-        error('Invalid argument(s) provided to CommandCenter upon launching:\n  %s',...
-            strjoin(varargin,'\n  '));
-    end
     debugLevel = Base.Logger.INFO;
     if debug
         loggerStartState = 'on';
@@ -136,6 +143,7 @@ try
             rmpref('Manager');
         end
     end
+    setappdata(hObject,'namespace_prefix',p.Results.namespace);
     
     % Update path
     warning('off','MATLAB:dispatcher:nameConflict');  % Overload setpref and dbquit
@@ -178,6 +186,8 @@ try
     setappdata(hObject,'ALLmodules',{})
     setappdata(hObject,'logger',handles.logger)
     set(handles.file_logger,'checked',handles.logger.visible)
+    handles.logger.log(['Using namespace prefix: "',...
+        getappdata(hObject,'namespace_prefix') '"'],handles.logger.DEBUG)
     
     % Convert panels to scrollPanels
     set(textH,'String','Making Panels'); drawnow;

--- a/Modules/+Drivers/+NIDAQ/@dev/dev.m
+++ b/Modules/+Drivers/+NIDAQ/@dev/dev.m
@@ -69,7 +69,7 @@ classdef dev < Modules.Driver
         init_error = true;                  % used to unload library if loaded
         load_error = true;                  % Prevent saving partially loaded lines
         init_warnings;                      % just informative
-        namespace
+        namespace_dev
     end
 
     properties(Constant,Hidden)
@@ -160,17 +160,17 @@ classdef dev < Modules.Driver
             end
             obj.SelfTest();
             obj.init_error = false;
-            obj.namespace = [strrep(mfilename('class'),'.','_') '_' DeviceChannel];
+            obj.namespace_dev = [obj.namespace '_' DeviceChannel];
             % Initialize lines from last time
-            if ispref(obj.namespace,'OutLines')
-                p = getpref(obj.namespace,'OutLines');
+            if ispref(obj.namespace_dev,'OutLines')
+                p = getpref(obj.namespace_dev,'OutLines');
                 for i = 1:numel(p)
                     line = p(i);
                     obj.addOutLine(line.line,line.name,line.limits,line.state);
                 end
             end
-            if ispref(obj.namespace,'InLines')
-                p = getpref(obj.namespace,'InLines');
+            if ispref(obj.namespace_dev,'InLines')
+                p = getpref(obj.namespace_dev,'InLines');
                 for i = 1:numel(p)
                     line = p(i);
                     obj.addInLine(line.line,line.name);
@@ -433,8 +433,8 @@ classdef dev < Modules.Driver
                     InLineStruct.name = InLineObj.name;
                     TempInLines(end+1) = InLineStruct;
                 end
-                setpref(obj.namespace,'OutLines',TempOutLines)
-                setpref(obj.namespace,'InLines',TempInLines)
+                setpref(obj.namespace_dev,'OutLines',TempOutLines)
+                setpref(obj.namespace_dev,'InLines',TempInLines)
             end
             if ~obj.init_error
                 % clear all tasks

--- a/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/analyze.m
+++ b/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/analyze.m
@@ -243,14 +243,13 @@ end
     end
     function save_data(varargin)
         save_state();
-        pref = [strrep(mfilename('class'),'.','_') '_analyze'];
         last = '';
-        if ispref(pref,'last_save')
-            last = getpref(pref,'last_save');
+        if ispref(obj.namespace,'last_save')
+            last = getpref(obj.namespace,'last_save');
         end
         [file,path] = uiputfile('*.mat','Save Analysis',last);
         if ~isequal(file,0)
-            setpref(pref,'last_save',path);
+            setpref(obj.namespace,'last_save',path);
             [~,~,ext] = fileparts(file);
             if isempty(ext) % Add extension if not specified
                 file = [file '.mat'];


### PR DESCRIPTION
Moved some of the [get|set]pref code around to be more logical. Added ability to load/save pref-related stuff to a prefixed group. You can now start CC in a different namespace - meaning modules and managers will add a prefix to their namespace (used as the group when setting/getting prefs).

Also, made namespace available to subclasses. This required making sure subclasses didn't try to make their own, and if they did, just rename it. Used vscode search-all, so fairly confident I get them all (just NIDAQ).

Hoping this makes debugging stuff a bit easier without having to change setup-specific stuff. Obviously this does not necessarily disconnect you from hardware nor removes the concept of singleton objects!