### PR TITLE
Fix/namespace

### DIFF
--- a/+Base/@Module/Module.m
+++ b/+Base/@Module/Module.m
@@ -32,20 +32,29 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
 
     methods(Static)
         [code,f] = uibuild(block,varargin)
-    end
-    methods(Sealed)
-        function obj = Module
-            warnStruct = warning('off','MATLAB:structOnObject');
-            obj.StructOnObject_state = warnStruct.state;
+        function namespace = get_namespace 
+            d = dbstack(1); %need to parse input and pass to namespace below 
+            e = Modules.Experiment.YouGotThisFar; %%REMOVE%% 
             hObject = findall(0,'name','CommandCenter');
             if isempty(hObject)
                 pre = '';
-                obj.logger = Base.Logger_console();
             else
                 pre = getappdata(hObject,'namespace_prefix');
             end
-            obj.namespace = [pre strrep(class(obj),'.','_')];
-            if isempty(hObject); return; end
+            namespace = [pre strrep(e,'.','_')];
+        end 
+    end
+    methods
+        function obj = Module 
+            warnStruct = warning('off','MATLAB:structOnObject');
+            obj.StructOnObject_state = warnStruct.state;
+            
+            obj.namespace = get_namespace; %set the namespace to value from static func
+            
+            if isempty(hObject) 
+                obj.logger = Base.Logger_console();
+                return; 
+            end
             mods = getappdata(hObject,'ALLmodules');
             obj.logger = getappdata(hObject,'logger');
             mods{end+1} = obj;
@@ -101,6 +110,8 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
             % *************************[END LEGACY]*****************************
             % ******************************************************************
         end
+    end 
+    methods(Sealed)
         function module_clean(obj,hObj,prop)
             to_remove = false(size(obj.(prop)));
             for i = 1:length(obj.(prop)) % Heterogeneous list; cant do in one line
@@ -456,4 +467,3 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
         end
     end
 end
-

--- a/+Base/@Module/Module.m
+++ b/+Base/@Module/Module.m
@@ -32,6 +32,8 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
 
     methods(Static)
         [code,f] = uibuild(block,varargin)
+    end
+    methods(Static,Sealed)
         function namespace = get_namespace 
             d = dbstack(1); %need to parse input and pass to namespace below 
             e = Modules.Experiment.YouGotThisFar; %%REMOVE%% 
@@ -42,18 +44,17 @@ classdef Module < Base.Singleton & Base.pref_handler & matlab.mixin.Heterogeneou
                 pre = getappdata(hObject,'namespace_prefix');
             end
             namespace = [pre strrep(e,'.','_')];
-        end 
+        end
     end
     methods
         function obj = Module 
             warnStruct = warning('off','MATLAB:structOnObject');
             obj.StructOnObject_state = warnStruct.state;
             
-            obj.namespace = get_namespace; %set the namespace to value from static func
-            
+            obj.namespace = obj.get_namespace();
             if isempty(hObject) 
                 obj.logger = Base.Logger_console();
-                return; 
+                return
             end
             mods = getappdata(hObject,'ALLmodules');
             obj.logger = getappdata(hObject,'logger');

--- a/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/analyze.m
+++ b/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/analyze.m
@@ -259,12 +259,12 @@ end
     function save_data(varargin)
         save_state();
         last = '';
-        if ispref(obj.namespace,'last_save')
-            last = getpref(obj.namespace,'last_save');
+        if ispref(namespace,'last_save') %namespace is returned by static method get_namespace
+            last = getpref(namespace,'last_save'); 
         end
         [file,path] = uiputfile('*.mat','Save Analysis',last);
         if ~isequal(file,0)
-            setpref(obj.namespace,'last_save',path);
+            setpref(namespace,'last_save',path);
             [~,~,ext] = fileparts(file);
             if isempty(ext) % Add extension if not specified
                 file = [file '.mat'];

--- a/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/analyze.m
+++ b/Modules/+Experiments/+AutoExperiment/@SpecSlowScan/analyze.m
@@ -259,7 +259,8 @@ end
     function save_data(varargin)
         save_state();
         last = '';
-        if ispref(namespace,'last_save') %namespace is returned by static method get_namespace
+        namespace = Base.Module.get_namespace();
+        if ispref(namespace,'last_save')
             last = getpref(namespace,'last_save'); 
         end
         [file,path] = uiputfile('*.mat','Save Analysis',last);


### PR DESCRIPTION
Fixes a bug generated by [this commit](https://github.com/mwalsh161/CommandCenter/commit/517fb2ed70c96ca44134d726b2e66e8085bebf38).

Consolidates code for computing namespace. Use dbstack and path parsing to build the namespace string. Allows for easy use from methods and static methods.