### PR TITLE
Check version on launch

### DIFF
--- a/CommandCenter.m
+++ b/CommandCenter.m
@@ -74,7 +74,7 @@ if strcmp(hObject.Visible,'on')
     return
 end
 % Check compatibility
-if true || verLessThan('matlab','9.4') % R2018a
+if verLessThan('matlab','9.4') % R2018a
     delete(hObject);
     msg = ['You are running a MATLAB version less than R2018a (version 9.4). ',...
            'You may encounter unexpected errors due to a major update in ',...

--- a/CommandCenter.m
+++ b/CommandCenter.m
@@ -73,6 +73,16 @@ if strcmp(hObject.Visible,'on')
     % Means it already exists, so do nothing
     return
 end
+% Check compatibility
+if true || verLessThan('matlab','9.4') % R2018a
+    delete(hObject);
+    msg = ['You are running a MATLAB version less than R2018a (version 9.4). ',...
+           'You may encounter unexpected errors due to a major update in ',...
+           'implicit superclass constructor calls.' newline newline...
+           'Update to a newer release >= R2018a!'];
+    errordlg(msg);
+    throwAsCaller(MException('CommandCenter:version',msg));
+end
 MATLAB_prefs = fullfile(prefdir,'matlabprefs.mat');
 key = 'ROYZNcVBgWkT8xiwcg5m2Nn9Gb4EAegF2XEN1i5adWD';  % CC key (helps avoid spam)
 [path,~,~] = fileparts(mfilename('fullpath'));


### PR DESCRIPTION
Big compatibility issue in between 2017b and 2018a with how implicit calls to constructors are handled. While this would be an easy fix to make backwards compatible, it probably isn't reasonable to assume future development will adhere (nor should they adhere to an old standard).

First introduced [here](https://www.mathworks.com/help/releases/R2018a/matlab/matlab_oop/class-constructor-methods.html?searchHighlight=implicit#mw_cd265b57-a33e-4947-beae-0b7a8d3f330f).