### PR TITLE
MATLAB interface for new hwserver PulseBlaster backend.

### DIFF
--- a/Modules/+Drivers/+PulseBlaster/Line.m
+++ b/Modules/+Drivers/+PulseBlaster/Line.m
@@ -1,0 +1,56 @@
+classdef Line < Modules.Driver
+    %Drivers.PulseBlaster.Line is a wrapper for a Prefs.Boolean
+    
+    properties(SetObservable,GetObservable)
+        state = Prefs.Boolean(false, 'set', 'set', 'help', 'A line of a PulseBlaster.')
+    end
+    properties(SetAccess=immutable,Hidden)
+        PB;     % Handle to Drivers.PulseBlaster parent
+        line;   % Index of the physical line of the parent that this D.PB.Line controls.
+    end
+    
+    methods(Static)
+        function obj = instance(parent, line)
+            mlock;
+            persistent Objects
+            if isempty(Objects)
+                Objects = Drivers.PulseBlaster.Line.empty(1,0);
+            end
+            [~,host_resolved] = resolvehost(parent.host);
+            id = [host_resolved '_line' num2str(line)];
+            for ii = 1:length(Objects)
+                if isvalid(Objects(ii)) && isvalid(Objects(ii).PB) && isequal(id, Objects(ii).singleton_id)
+                    obj = Objects(ii);
+                    return
+                end
+            end
+            obj = Drivers.PulseBlaster.Line(parent, line);
+            obj.singleton_id = id;
+            Objects(end+1) = obj;
+        end
+    end
+    methods(Access=private)
+        function obj = Line(parent, line)
+            obj.PB = parent;
+            obj.line = line;
+            p = obj.get_meta_pref('state');
+            p.help_text = ['Line ' num2str(line) ' of the PulseBlaster at ' parent.host];
+            obj.set_meta_pref('state', p);
+            addlistener(obj.PB,'ObjectBeingDestroyed',@(~,~)obj.delete);
+            %addlistener(obj.PB,'running','PostSet',@(~,~)obj.updateRunning);
+        end
+    end
+    methods
+        function delete(obj)
+            % Do nothing.
+        end
+        function val = get(obj, ~, ~)
+            lines = obj.PB.getLines();
+            val = lines(obj.line);
+        end
+        function val = set(obj, val, ~)
+            obj.PB.setLines(obj.line, val);
+        end
+    end
+end
+

--- a/Modules/+Drivers/+PulseBlaster/Remote.m
+++ b/Modules/+Drivers/+PulseBlaster/Remote.m
@@ -22,6 +22,7 @@ classdef Remote < Modules.Driver & Drivers.PulseTimer_invisible
     
     methods(Static)
         function obj = instance(ip)
+            warning("Drivers.PulseBlaser.Remote is decrepitated and should be replaced with Drivers.PulseBlaster")
             mlock;
             persistent Objects
             if isempty(Objects)

--- a/Modules/+Drivers/+PulseBlaster/StaticLines.m
+++ b/Modules/+Drivers/+PulseBlaster/StaticLines.m
@@ -25,6 +25,7 @@ classdef StaticLines < Modules.Driver
     
     methods(Static)
         function obj = instance(host_ip,interactive)
+            warning("Drivers.PulseBlaser.StaticLines is decrepitated and should be replaced with Drivers.PulseBlaster")
             if nargin < 2
                 interactive = true;
             end

--- a/Modules/+Drivers/PulseBlaster.m
+++ b/Modules/+Drivers/PulseBlaster.m
@@ -78,6 +78,10 @@ classdef PulseBlaster < Modules.Driver & Drivers.PulseTimer_invisible
         end
         
         function response = load(obj, program, clock)
+            if iscell(program)  % Process cell array of strings for backwards compatibility.
+                program = strjoin(program, newline);
+            end
+            
             assert(ischar(program))
             assert(~isempty(program))
             if nargin == 2
@@ -88,7 +92,7 @@ classdef PulseBlaster < Modules.Driver & Drivers.PulseTimer_invisible
             end
         end
         function response = getProgram(obj)
-            response = obj.com('stop');
+            response = obj.com('getProgram');
         end
         
         function response = isStatic(obj)

--- a/Modules/+Drivers/PulseBlaster.m
+++ b/Modules/+Drivers/PulseBlaster.m
@@ -1,0 +1,107 @@
+classdef PulseBlaster < Modules.Driver & Drivers.PulseTimer_invisible
+    %PULSEBLASTER Connects with hwserver on host machine to control
+    % the PulseBlaster via the interpreter program.
+    % Call with the IP of the host computer (singleton based on ip)
+    
+    properties(Constant)
+        clk = 500           % MHz?
+        resolution = 2;     % ns
+        minDuration = 10;   % Minimum duration in ns
+        maxRepeats = 2^20;  % positive integer value
+        
+        hwname = 'PulseBlaster';
+    end
+    properties(SetAccess=private,Hidden)
+        connection
+        lines
+    end
+    properties(SetAccess=immutable)
+        host = '';
+    end
+%     properties(SetObservable,GetObservable,AbortSet)
+%         host = Prefs.String();
+%     end
+    
+    methods(Static)
+        function obj = instance(host_ip)
+            mlock;
+            persistent Objects
+            if isempty(Objects)
+                Objects = Drivers.PulseBlaster.empty(1,0);
+            end
+            [~,host_resolved] = resolvehost(host_ip);
+            for i = 1:length(Objects)
+                if isvalid(Objects(i)) && isequal(host_resolved, Objects(i).singleton_id)
+                    obj = Objects(i);
+                    return
+                end
+            end
+            obj = Drivers.PulseBlaster(host_ip);
+            obj.singleton_id = host_resolved;
+            Objects(end+1) = obj;
+        end
+    end
+    methods(Access=private)
+        function obj = PulseBlaster(ip)
+            obj.host = ip;
+            obj.connection = hwserver(ip);
+            obj.spawnLines();
+        end
+        function spawnLines(obj)
+            state = obj.getLines();
+            
+            for ii = 1:length(state)    % Eventually, have a system to only initialize certain lines (based on a pref) and to name them.
+                obj.lines = [obj.lines Drivers.PulseBlaster.Line.instance(obj, ii)];
+            end
+        end
+        function killLines(obj)
+            delete(obj.lines);
+        end
+    end
+    methods
+        function delete(obj)
+            obj.killLines();
+            delete(obj.connection);
+        end
+        function response = com(obj, varargin)
+            response = obj.connection.com(obj.hwname, varargin{:});
+        end
+        
+        function response = start(obj)
+            response = obj.com('start');
+        end
+        function response = stop(obj)
+            response = obj.com('stop');
+        end
+        function response = reset(obj)
+            response = obj.com('setLines')';
+        end
+        
+        function response = load(obj, program, clock)
+            assert(ischar(program))
+            assert(~isempty(program))
+            if nargin == 2
+                response = obj.com('load', program);
+            else
+                assert(clock > 0)
+                response = obj.com('load', program, clock);
+            end
+        end
+        function response = getProgram(obj)
+            response = obj.com('stop');
+        end
+        
+        function response = isStatic(obj)
+            response = obj.com('isStatic');
+        end
+        function response = setAllLines(obj, lines)         % Pass a logical array
+            response = obj.com('setAllLines', lines)';
+        end
+        function response = setLines(obj, indices, values)  % Pass a list of indices to change
+            response = obj.com('setLines', indices, values)';
+        end
+        function response = getLines(obj)
+            response = obj.com('getLines')';
+        end
+    end
+end

--- a/Modules/+Experiments/+PulseSequenceSweep/@PulseSequenceSweep_invisible/PulseSequenceSweep_invisible.m
+++ b/Modules/+Experiments/+PulseSequenceSweep/@PulseSequenceSweep_invisible/PulseSequenceSweep_invisible.m
@@ -73,7 +73,7 @@ classdef PulseSequenceSweep_invisible < Modules.Experiment
                 obj.pbH = [];
             end
             try
-                obj.pbH = Drivers.PulseBlaster.Remote.instance(val);
+                obj.pbH = Drivers.PulseBlaster.instance(val);
             catch err
                 obj.pbH = [];
                 obj.pb_IP = 'None Set';

--- a/Modules/+Sources/+msquared/common_invisible.m
+++ b/Modules/+Sources/+msquared/common_invisible.m
@@ -65,13 +65,13 @@ classdef(Abstract) common_invisible < Modules.Source & Sources.TunableLaser_invi
     methods
         function on(obj)
             assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
-            obj.PulseBlaster.lines(obj.PBline) = true;
+            obj.PulseBlaster.lines(obj.PBline).state = true;
             obj.source_on = true;
         end
         function off(obj)
             assert(~isempty(obj.PulseBlaster),'No PulseBlaster IP set!')
             obj.source_on = false;
-            obj.PulseBlaster.lines(obj.PBline) = false;
+            obj.PulseBlaster.lines(obj.PBline).state = false;
         end
 
         function updateStatus(obj)
@@ -302,16 +302,16 @@ classdef(Abstract) common_invisible < Modules.Source & Sources.TunableLaser_invi
 
         function val = set_PBline(obj,val,~)
             if ~isempty(obj.PulseBlaster)
-                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
+                obj.source_on = obj.PulseBlaster.lines(obj.PBline).state;
             end
         end
         function host = set_pb_host(obj,host,~)
-            err = obj.connect_driver('PulseBlaster','PulseBlaster.StaticLines',host);
+            err = obj.connect_driver('PulseBlaster','PulseBlaster',host);
             if isempty(obj.PulseBlaster)
                 host = obj.no_server;
                 obj.pb_host = host; % Set explicitly because might error below if we got here
             else
-                obj.source_on = obj.PulseBlaster.lines(obj.PBline);
+                obj.source_on = obj.PulseBlaster.lines(obj.PBline).state;
             end
             if ~isempty(err)
                 rethrow(err)

--- a/Modules/+Sources/Cobolt_PB.m
+++ b/Modules/+Sources/Cobolt_PB.m
@@ -12,7 +12,7 @@ classdef Cobolt_PB < Modules.Source
         
         PB_line =       Prefs.Integer(1, 'min', 1, 'help_text', 'Pulse Blaster flag bit (indexed from 1)');
         PB_host =       Prefs.String('No Server', 'set', 'set_pb_host', 'help_text', 'hostname of hwserver computer with PB');
-        PB_running =    Prefs.Boolean(false, 'readonly', true, 'help_text', 'Boolean specifying if StaticLines program running');
+%         PB_running =    Prefs.Boolean(false, 'readonly', true, 'help_text', 'Boolean specifying if StaticLines program running');
         
         prefs =         {'cobolt_host', 'PB_line', 'PB_host', 'power', 'diode_on'};
         show_prefs =    {'PB_host', 'PB_line', 'PB_running', 'cobolt_host', 'power', 'diode_on', 'temperature', 'diode_age', 'diode_sn'};
@@ -131,14 +131,14 @@ classdef Cobolt_PB < Modules.Source
             end
             err = [];
             try
-                obj.PulseBlaster = Drivers.PulseBlaster.StaticLines.instance(val); %#ok<*MCSUP>
-                obj.source_on = obj.PulseBlaster.lines(obj.PB_line);
-                delete(obj.listeners)
-                obj.listeners = addlistener(obj.PulseBlaster, 'running', 'PostSet', @obj.isRunning);
-                obj.isRunning;
+                obj.PulseBlaster = Drivers.PulseBlaster.instance(val); %#ok<*MCSUP>
+                obj.source_on = obj.PulseBlaster.lines(obj.PB_line).state;
+%                 delete(obj.listeners)
+%                 obj.listeners = addlistener(obj.PulseBlaster, 'running', 'PostSet', @obj.isRunning);
+%                 obj.isRunning;
             catch err
                 obj.PulseBlaster = [];
-                delete(obj.listeners)
+%                 delete(obj.listeners)
                 obj.source_on = false;
                 val = 'No Server';
             end
@@ -173,18 +173,18 @@ classdef Cobolt_PB < Modules.Source
         
         function on(obj)
             assert(~isempty(obj.PulseBlaster), 'No host set!')
-            obj.PulseBlaster.lines(obj.PB_line) = true;
+            obj.PulseBlaster.lines(obj.PB_line).state = true;
             obj.source_on = true; 
         end
         function off(obj)
             assert(~isempty(obj.PulseBlaster), 'No host set!')
             obj.source_on = false;
-            obj.PulseBlaster.lines(obj.PB_line) = false;
+            obj.PulseBlaster.lines(obj.PB_line).state = false;
         end
         
-        function isRunning(obj,varargin)
-            obj.PB_running = obj.PulseBlaster.running;
-        end
+%         function isRunning(obj,varargin)
+%             obj.PB_running = obj.PulseBlaster.running;
+%         end
     end
 end
         


### PR DESCRIPTION
This pull request adds the `Drivers.PulseBlaster` driver that interfaces with [new hwserver PulseBlaster functionality](https://github.mit.edu/mpwalsh/hwserver/pull/6). The two notable differences are:
- The new python3-compatible hwserver code now keeps track of static lines -- rather than local `Drivers.PulseBlaster.StaticLines` -- so multiple clients can use the same PulseBlaster.
- The parent `Drivers.PulseBlaster` spawns `Drivers.PulseBlaster.Line`s for each line of the PulseBlaster, each having a `state = Prefs.Boolean` for the state of the static line. This modernizes the driver in preparation for in-progress general functions that interface directly with `Prefs`. Functions still exist to interface with the PulseBlaster in a manner similar to the old drivers.

For this pull request, the old `Drivers.PulseBlaster.StaticLines` and `Drivers.PulseBlaster.Remote` drivers are unchanged. Modules with PulseBlaster functionality likewise are unchanged and still use the old interfaces. This pull request is simply a first step towards migration.